### PR TITLE
Modernize clir installation and R support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,10 @@ jobs:
         with:
           r-version: ${{ matrix.r-version }}
           use-public-rspm: true
+      - name: Install pak system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y libcurl4-openssl-dev
       - name: Install clir from the checkout
         run: |
           # shellcheck disable=SC2016

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ on:
       r-version:
         required: false
         type: string
-        description: R version to use
+        description: R version to use for the manually selected workflow
         default: release
 permissions:
   contents: read
@@ -38,34 +38,62 @@ jobs:
       github.event_name == 'push'
       || github.event_name == 'pull_request'
       || (github.event_name == 'workflow_dispatch' && inputs.workflow == 'lint-and-test')
+    strategy:
+      fail-fast: false
+      matrix:
+        r-version: [devel, release, oldrel-1]
     permissions:
       contents: read
     uses: dceoy/gha-for-devops/.github/workflows/r-package-lint.yml@main  # zizmor: ignore[unpinned-uses]
     with:
       package-path: .
-      r-version: ${{ inputs.r-version || 'release' }}
+      r-version: ${{ matrix.r-version }}
       runs-on: ubuntu-latest
       r-libs-user: /usr/local/lib/R/site-library
       lint-package: false
-  format-and-pr:
+  r-tests:
     if: >
-      github.event_name == 'pull_request'
-      || (github.event_name == 'workflow_dispatch' && inputs.workflow == 'format')
-    permissions:
-      contents: write
-      pull-requests: write
-    uses: dceoy/gha-for-devops/.github/workflows/r-package-format-and-pr.yml@main  # zizmor: ignore[unpinned-uses]
-    with:
-      package-path: .
-      r-version: ${{ inputs.r-version || 'release' }}
-      runs-on: ubuntu-latest
-      format-package: false
+      github.event_name == 'push'
+      || github.event_name == 'pull_request'
+      || (github.event_name == 'workflow_dispatch' && inputs.workflow == 'lint-and-test')
+    strategy:
+      fail-fast: false
+      matrix:
+        r-version: [devel, release, oldrel-1]
+    runs-on: ubuntu-latest
+    env:
+      CLIR_SOURCE_DIR: ${{ github.workspace }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Set up R
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6  # v2.12.1
+        with:
+          r-version: ${{ matrix.r-version }}
+          use-public-rspm: true
+      - name: Install clir from the checkout
+        run: |
+          # shellcheck disable=SC2016
+          r_version=$(R --vanilla --slave -e 'cat(paste(R.version$major, strsplit(R.version$minor, ".", fixed = TRUE)[[1]][1], sep = "."))')
+          export R_LIBS_USER="${GITHUB_WORKSPACE}/r/${r_version}/library"
+          echo "R_LIBS_USER=${R_LIBS_USER}" >> "${GITHUB_ENV}"
+          echo "PATH=${GITHUB_WORKSPACE}/bin:${PATH}" >> "${GITHUB_ENV}"
+          ./install_clir.sh
+      - name: Run focused regression tests
+        run: |
+          Rscript tests/test_util.R
+          bash tests/test_cli.sh
   cli-test:
     if: >
       github.event_name == 'push'
       || github.event_name == 'pull_request'
       || (github.event_name == 'workflow_dispatch' && inputs.workflow == 'lint-and-test')
     runs-on: macos-latest
+    env:
+      CLIR_SOURCE_DIR: ${{ github.workspace }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -79,43 +107,56 @@ jobs:
           use-public-rspm: true
       - name: Set environment variables
         run: |
-          {
-            echo "PATH=${HOME}/.clir/bin:${PATH}";
-            echo "R_LIBS_USER=${HOME}/.clir/r/library";
-          } >> "${GITHUB_ENV}"
+          # shellcheck disable=SC2016
+          r_version=$(R --vanilla --slave -e 'cat(paste(R.version$major, strsplit(R.version$minor, ".", fixed = TRUE)[[1]][1], sep = "."))')
+          export R_LIBS_USER="${GITHUB_WORKSPACE}/r/${r_version}/library"
+          echo "PATH=${GITHUB_WORKSPACE}/bin:${PATH}" >> "${GITHUB_ENV}"
+          echo "R_LIBS_USER=${R_LIBS_USER}" >> "${GITHUB_ENV}"
       - name: Install clir
-        run: |
-          ./install_clir.sh
+        run: ./install_clir.sh
       - name: Test configuration
         run: |
           clir --version
           clir config
           clir cran --list
           clir cran https://cran.ism.ac.jp/
-          clir drat dmlc
           clir config
           clir config --init
       - name: Test installation
         run: |
           clir update
           clir install foreach doParallel tidyverse
-          clir install --devt=cran foreach doParallel tidyverse
+          clir install cran::foreach cran::doParallel
           clir validate foreach doParallel tidyverse
           clir session foreach doParallel tidyverse
       - name: Test uninstallation
         run: |
           clir uninstall foreach doSNOW
-          [[ ! -d "${HOME}/.clir/r/library/foreach" ]]
-          [[ ! -d "${HOME}/.clir/r/library/doSNOW" ]]
+          [[ ! -d "${R_LIBS_USER}/foreach" ]]
+          [[ ! -d "${R_LIBS_USER}/doSNOW" ]]
       - name: Test downloading
         run: |
           clir download tidyverse gridExtra
           ls -l tidyverse* gridExtra*
+  format-and-pr:
+    if: >
+      github.event_name == 'pull_request'
+      || (github.event_name == 'workflow_dispatch' && inputs.workflow == 'format')
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: dceoy/gha-for-devops/.github/workflows/r-package-format-and-pr.yml@main  # zizmor: ignore[unpinned-uses]
+    with:
+      package-path: .
+      r-version: ${{ inputs.r-version || 'release' }}
+      runs-on: ubuntu-latest
+      format-package: false
   dependabot-auto-merge:
     if: >
       github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
     needs:
       - r-lint
+      - r-tests
       - cli-test
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -1,159 +1,83 @@
 # clir
 
-R Package Installer for Command Line Interface
+R package installer for the command line.
 
 [![CI](https://github.com/dceoy/clir/actions/workflows/ci.yml/badge.svg)](https://github.com/dceoy/clir/actions/workflows/ci.yml)
 
-#### Supported versions
+## Supported R versions
 
-|    R     |    clir     |
-| :------: | :---------: |
-| &ge; 3.5 | &ge; v1.1.0 |
-| &lt; 3.5 | &lt; v1.0.8 |
+clir continuously tests the following support policy:
+
+| Platform | R versions |
+| :------: | :---------- |
+| Linux | R-devel, current release, and oldrel-1 |
+| macOS | current release (CLI smoke tests) |
 
 ## Usage
 
-#### Installation or update of R packages
+`clir install` and `clir update` use [`pak::pkg_install()`](https://pak.r-lib.org/reference/pkg_install.html).
+Package references are passed to pak unchanged, so CRAN, Bioconductor, GitHub, Git, and package archive sources
+can use the same command:
 
-- Install packages via CRAN using `install.packages()`.
+```sh
+clir install dplyr
+clir install bioc::GenomicRanges
+clir install r-lib/cli
+clir install git::https://example.com/packages/example.git
+clir update
+```
 
-  ```sh
-  $ clir install foreach doParallel tidyverse
-  ```
+Only required package dependencies are installed by default. Use pak's package-reference parameters when a
+different dependency policy is needed.
 
-- Install or update packages via CRAN using `devtools::install_cran()`.
+Other commands are available for configuration and package maintenance:
 
-  ```sh
-  $ clir install --devt=cran foreach doParallel tidyverse
-  ```
+```sh
+clir config --init
+clir cran https://cloud.r-project.org/
+clir validate dplyr
+clir session dplyr
+clir download dplyr
+clir uninstall dplyr
+```
 
-- Install or update packages via GitHub using `devtools::install_github()`.
-
-  ```sh
-  $ clir install --devt=github IRkernel/IRkernel
-  ```
-
-- Install or update packages via Bioconductor using `BiocManager::install()`.
-
-  ```sh
-  $ clir install --bioc GenomicRanges
-  ```
-
-- Install or update packages via Bioconductor using `devtools::install_bioc()`.
-
-  ```sh
-  $ clir install --devt=bioc GenomicRanges
-  ```
-
-- Update packages via CRAN using `update.packages()`.
-
-  ```sh
-  $ clir update
-  ```
-
-#### Validation of installed R packages
-
-- Validate loading of installed packages.
-
-  ```sh
-  $ clir validate foreach doParallel tidyverse
-  ```
-
-#### Session information
-
-- Load packages and print session information.
-
-  ```sh
-  $ clir session foreach doParallel tidyverse
-  ```
-
-Run `clir --help` for information.
+The former `drat`, `--devt`, and `--bioc` interfaces are removed. Use generic pak package references instead.
+Run `clir --help` for the complete command reference.
 
 ## Installation
 
-#### Installation into a local environment
-
-1.  Install R and the additional packages.
-
-    ```sh
-    # Ubuntu
-    $ sudo apt -y update
-    $ sudo apt -y install ca-certificates curl git r-base r-cran-devtools r-cran-docopt r-cran-yaml
-
-    # macOS with Homebrew
-    $ brew install curl git r
-    ```
-
-2.  Check out clir and run `install_clir.sh`.
-
-    ```sh
-    $ git clone https://github.com/dceoy/clir.git ~/.clir
-    ```
-
-3.  Install clir and the dependencies.
-
-    ```sh
-    $ ~/.clir/install_clir.sh
-    ```
-
-    `install_clir.sh` installs the following R packages:
-    - [docopt](https://cran.r-project.org/web/packages/docopt/index.html)
-    - [yaml](https://cran.r-project.org/web/packages/yaml/index.html)
-    - [devtools](https://cran.r-project.org/web/packages/devtools/index.html)
-    - [drat](https://cran.r-project.org/web/packages/drat/index.html)
-    - [BiocManager](https://cran.r-project.org/web/packages/BiocManager/index.html)
-
-    clir depends on docopt and yaml, and uses devtools, drat, and BiocManager additionally if they are available.
-
-    Run `~/.clir/install_clir.sh --help` for more details of the installer.
-
-4.  Set `~/.clir/bin` into `${PATH}` and set `~/.clir/r/library` into `${R_LIBS_USER}` or `${R_LIBS}`.
-
-    ```sh
-    $ echo 'export PATH="${HOME}/.clir/bin:${PATH}"' >> ~/.bash_profile
-    $ echo 'export R_LIBS_USER="${HOME}/.clir/r/library"' >> ~/.bash_profile
-    $ source ~/.bash_profile
-    ```
-
-    If you use Zsh, modify `~/.zshrc` instead of `~/.bash_profile`.
-
-#### Installation into a system
-
-Run the installer with `--root` if you install clir into a system. (clir is going to be installed into `/usr/local` then.)
+Install R and Git, then check out clir and run the installer:
 
 ```sh
-$ curl -LSO https://raw.githubusercontent.com/dceoy/clir/master/install_clir.sh
-$ chmod +x install_clir.sh
-yy$ sudo ./install_clir.sh --root
-$ rm install_clir.sh
+git clone https://github.com/dceoy/clir.git ~/.clir
+~/.clir/install_clir.sh
 ```
 
-## Update
-
-#### Update of clir in a local environment
+The installer bootstraps only `docopt`, `yaml`, and `pak`. Use `--root` to install into `/usr/local`:
 
 ```sh
-$ ~/.clir/install_clir.sh
+sudo ~/.clir/install_clir.sh --root
 ```
 
-#### Update of clir installed into the system
+Add the clir `bin` directory to `PATH` after installation. `install_clir.sh --help` lists all installer options.
 
-```sh
-$ sudo /usr/local/src/clir/install_clir.sh --root
+## Libraries and configuration
+
+When neither `R_LIBS_USER` nor `R_LIBS` is set, clir uses an R-version-aware library:
+
+```text
+~/.clir/r/<R-major>.<R-minor>/library
 ```
 
-## Configuration
+For example, R 4.3 uses `~/.clir/r/4.3/library`. Explicit `R_LIBS_USER` and `R_LIBS` values remain authoritative.
+The installer option `--delete-r-lib` can reset only the current versioned library below the clir-managed `r`
+directory. It rejects external paths, the managed root, and symlinked targets.
 
-- Library path
+Configuration is stored in `r/clir.yml` below the clir root using named repositories:
 
-  R packages are installed into a directory in `${R_LIBS_USER}` nor `${R_LIBS}`.
-  If neither of them is set, a default library path is used.
-  The default path can be checked as follows:
+```yaml
+repos:
+  CRAN: https://cloud.r-project.org/
+```
 
-  ```sh
-  $ R --slave -e '.libPaths()[1]'
-  ```
-
-- CRAN and Drat repositories
-
-  clir saves URLs of CRAN mirrors and Drat repositories into `~/.clir/r/clir.yml` as a YAML file.
+Existing configurations using `cran_urls` are read and normalized when clir is upgraded.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ clir install git::https://example.com/packages/example.git
 clir update
 ```
 
-Only required package dependencies are installed by default. Use pak's package-reference parameters when a
-different dependency policy is needed.
+Only required package dependencies are installed by default. clir does not
+expose an option for installing Suggests or selecting a different dependency
+policy.
 
 Other commands are available for configuration and package maintenance:
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,15 @@ Run `clir --help` for the complete command reference.
 
 ## Installation
 
-Install R and Git, then check out clir and run the installer:
+Install R and Git. On Debian or Ubuntu, install the libcurl development
+headers used when pak builds its dependencies from source:
+
+```sh
+sudo apt-get update
+sudo apt-get install --no-install-recommends -y libcurl4-openssl-dev
+```
+
+Then check out clir and run the installer:
 
 ```sh
 git clone https://github.com/dceoy/clir.git ~/.clir
@@ -63,13 +71,15 @@ Add the clir `bin` directory to `PATH` after installation. `install_clir.sh --he
 
 ## Libraries and configuration
 
-When neither `R_LIBS_USER` nor `R_LIBS` is set, clir uses an R-version-aware library:
+When neither `R_LIBS_USER` nor `R_LIBS` is set, the `bin/clir` launcher sets
+an R-version-aware library before R starts:
 
 ```text
 ~/.clir/r/<R-major>.<R-minor>/library
 ```
 
-For example, R 4.3 uses `~/.clir/r/4.3/library`. Explicit `R_LIBS_USER` and `R_LIBS` values remain authoritative.
+For example, R 4.3 uses `~/.clir/r/4.3/library`. Explicit `R_LIBS_USER` and
+`R_LIBS` values remain authoritative across invocations.
 The installer option `--delete-r-lib` can reset only the current versioned library below the clir-managed `r`
 directory. It rejects external paths, the managed root, and symlinked targets.
 

--- a/bin/clir
+++ b/bin/clir
@@ -1,1 +1,28 @@
-../src/clir.R
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_path=$(realpath "${BASH_SOURCE[0]}")
+clir_root=$(realpath "$(dirname "${script_path}")/..")
+
+# R synthesizes R_LIBS_USER during startup. Set the managed default before
+# starting R so the launcher and the installer use the same library. An
+# explicit R_LIBS_USER remains authoritative; when only R_LIBS is explicit,
+# keep R from inserting its synthesized user library ahead of it.
+if [[ -n "${R_LIBS_USER:-}" ]]; then
+  :
+elif [[ -n "${R_LIBS:-}" ]]; then
+  export R_LIBS_USER=''
+else
+  # shellcheck disable=SC2016
+  r_version=$(R --vanilla --slave -e '
+    cat(paste(
+      R.version$major,
+      strsplit(R.version$minor, ".", fixed = TRUE)[[1]][1],
+      sep = "."
+    ))
+  ')
+  export R_LIBS_USER="${clir_root}/r/${r_version}/library"
+fi
+
+exec Rscript "${clir_root}/src/clir.R" "$@"

--- a/bin/clir
+++ b/bin/clir
@@ -9,10 +9,54 @@ clir_root=$(realpath "$(dirname "${script_path}")/..")
 # starting R so the launcher and the installer use the same library. An
 # explicit R_LIBS_USER remains authoritative; when only R_LIBS is explicit,
 # keep R from inserting its synthesized user library ahead of it.
+function read_r_library_env {
+  local startup_mode="${1:-}"
+  if [[ "${startup_mode}" = '--vanilla' ]]; then
+    # shellcheck disable=SC2016
+    R --vanilla --slave -e '
+      cat(paste(Sys.getenv(c("R_LIBS", "R_LIBS_USER")), collapse = "\034"));
+    '
+  else
+    # shellcheck disable=SC2016
+    R --no-save --no-restore --no-echo --slave -e '
+      cat(paste(Sys.getenv(c("R_LIBS", "R_LIBS_USER")), collapse = "\034"));
+    '
+  fi
+}
+
+function use_r_startup_library {
+  local separator=$'\034'
+  local startup_env vanilla_env
+  local startup_r_libs startup_r_libs_user
+  local vanilla_r_libs vanilla_r_libs_user
+  startup_env=$(read_r_library_env)
+  vanilla_env=$(read_r_library_env --vanilla)
+  startup_r_libs="${startup_env%%"${separator}"*}"
+  startup_r_libs_user="${startup_env#*"${separator}"}"
+  vanilla_r_libs="${vanilla_env%%"${separator}"*}"
+  vanilla_r_libs_user="${vanilla_env#*"${separator}"}"
+
+  if [[ -n "${startup_r_libs}" && "${startup_r_libs}" != 'NULL' &&
+    "${startup_r_libs}" != "${vanilla_r_libs}" ]]; then
+    export R_LIBS="${startup_r_libs}"
+    export R_LIBS_USER='NULL'
+    return 0
+  fi
+  if [[ -n "${startup_r_libs_user}" &&
+    "${startup_r_libs_user}" != 'NULL' &&
+    "${startup_r_libs_user}" != "${vanilla_r_libs_user}" ]]; then
+    export R_LIBS_USER="${startup_r_libs_user}"
+    return 0
+  fi
+  return 1
+}
+
 if [[ -n "${R_LIBS_USER:-}" && "${R_LIBS_USER:-}" != 'NULL' ]]; then
   :
 elif [[ -n "${R_LIBS:-}" && "${R_LIBS:-}" != 'NULL' ]]; then
   export R_LIBS_USER='NULL'
+elif use_r_startup_library; then
+  :
 else
   # shellcheck disable=SC2016
   r_version=$(R --vanilla --slave -e '

--- a/bin/clir
+++ b/bin/clir
@@ -9,7 +9,7 @@ clir_root=$(realpath "$(dirname "${script_path}")/..")
 # starting R so the launcher and the installer use the same library. An
 # explicit R_LIBS_USER remains authoritative; when only R_LIBS is explicit,
 # keep R from inserting its synthesized user library ahead of it.
-if [[ -n "${R_LIBS_USER:-}" ]]; then
+if [[ -n "${R_LIBS_USER:-}" && "${R_LIBS_USER:-}" != 'NULL' ]]; then
   :
 elif [[ -n "${R_LIBS:-}" ]]; then
   export R_LIBS_USER='NULL'

--- a/bin/clir
+++ b/bin/clir
@@ -69,4 +69,8 @@ else
   export R_LIBS_USER="${clir_root}/r/${r_version}/library"
 fi
 
+# Keep the probe-selected library stable if a runtime profile changes the
+# public R_LIBS variables before src/clir.R resolves the package library.
+export CLIR_R_LIBS="${R_LIBS-}"
+export CLIR_R_LIBS_USER="${R_LIBS_USER-}"
 exec Rscript "${clir_root}/src/clir.R" "$@"

--- a/bin/clir
+++ b/bin/clir
@@ -18,7 +18,7 @@ function read_r_library_env {
     '
   else
     # shellcheck disable=SC2016
-    R --no-save --no-restore --no-echo --slave -e '
+    R --no-site-file --no-init-file --no-save --no-restore --no-echo --slave -e '
       cat(paste(Sys.getenv(c("R_LIBS", "R_LIBS_USER")), collapse = "\034"));
     '
   fi

--- a/bin/clir
+++ b/bin/clir
@@ -7,8 +7,8 @@ clir_root=$(realpath "$(dirname "${script_path}")/..")
 
 # R synthesizes R_LIBS_USER during startup. Set the managed default before
 # starting R so the launcher and the installer use the same library. An
-# explicit R_LIBS_USER remains authoritative; when only R_LIBS is explicit,
-# keep R from inserting its synthesized user library ahead of it.
+# explicit R_LIBS_USER remains authoritative. R combines R_LIBS before
+# R_LIBS_USER, so selecting R_LIBS does not require discarding the user tree.
 function read_r_library_env {
   local startup_mode="${1:-normal}"
   # shellcheck disable=SC2016
@@ -103,7 +103,6 @@ function use_r_startup_library {
   if [[ -n "${startup_r_libs}" && "${startup_r_libs}" != 'NULL' &&
     "${startup_r_libs}" != "${vanilla_r_libs}" ]]; then
     export R_LIBS="${startup_r_libs}"
-    export R_LIBS_USER='NULL'
     return 0
   fi
   if [[ -n "${startup_r_libs_user}" &&
@@ -120,7 +119,6 @@ function use_r_startup_library {
   if [[ "${startup_has_library_assignment}" = 1 ]]; then
     if [[ -n "${startup_r_libs}" && "${startup_r_libs}" != 'NULL' ]]; then
       export R_LIBS="${startup_r_libs}"
-      export R_LIBS_USER='NULL'
       return 0
     fi
     if [[ -n "${startup_r_libs_user}" &&
@@ -136,7 +134,7 @@ r_version=''
 if [[ -n "${R_LIBS_USER:-}" && "${R_LIBS_USER:-}" != 'NULL' ]]; then
   :
 elif [[ -n "${R_LIBS:-}" && "${R_LIBS:-}" != 'NULL' ]]; then
-  export R_LIBS_USER='NULL'
+  export R_LIBS
 elif use_r_startup_library; then
   :
 else

--- a/bin/clir
+++ b/bin/clir
@@ -12,7 +12,7 @@ clir_root=$(realpath "$(dirname "${script_path}")/..")
 if [[ -n "${R_LIBS_USER:-}" ]]; then
   :
 elif [[ -n "${R_LIBS:-}" ]]; then
-  export R_LIBS_USER=''
+  export R_LIBS_USER='NULL'
 else
   # shellcheck disable=SC2016
   r_version=$(R --vanilla --slave -e '

--- a/bin/clir
+++ b/bin/clir
@@ -11,7 +11,7 @@ clir_root=$(realpath "$(dirname "${script_path}")/..")
 # keep R from inserting its synthesized user library ahead of it.
 if [[ -n "${R_LIBS_USER:-}" && "${R_LIBS_USER:-}" != 'NULL' ]]; then
   :
-elif [[ -n "${R_LIBS:-}" ]]; then
+elif [[ -n "${R_LIBS:-}" && "${R_LIBS:-}" != 'NULL' ]]; then
   export R_LIBS_USER='NULL'
 else
   # shellcheck disable=SC2016

--- a/bin/clir
+++ b/bin/clir
@@ -10,47 +10,49 @@ clir_root=$(realpath "$(dirname "${script_path}")/..")
 # explicit R_LIBS_USER remains authoritative; when only R_LIBS is explicit,
 # keep R from inserting its synthesized user library ahead of it.
 function read_r_library_env {
-  local startup_mode="${1:-}"
-  if [[ "${startup_mode}" = '--vanilla' ]]; then
-    # shellcheck disable=SC2016
-    R --vanilla --slave -e '
-      cat(paste(Sys.getenv(c("R_LIBS", "R_LIBS_USER")), collapse = "\034"));
-    '
-  else
-    # shellcheck disable=SC2016
+  local marker_r_libs="${1}"
+  local marker_r_libs_user="${2}"
+  # shellcheck disable=SC2016
+  R_LIBS="${marker_r_libs}" R_LIBS_USER="${marker_r_libs_user}" \
     R --no-site-file --no-init-file --no-save --no-restore --no-echo --slave -e '
-      cat(paste(Sys.getenv(c("R_LIBS", "R_LIBS_USER")), collapse = "\034"));
+      libs <- Sys.getenv(c("R_LIBS", "R_LIBS_USER"));
+      version <- paste(
+        R.version$major,
+        strsplit(R.version$minor, ".", fixed = TRUE)[[1]][1],
+        sep = "."
+      );
+      cat(paste(c(libs, version), collapse = "\034"));
     '
-  fi
 }
 
 function use_r_startup_library {
   local separator=$'\034'
-  local startup_env vanilla_env
+  local marker_r_libs="__clir_r_libs_probe_$$"
+  local marker_r_libs_user="__clir_r_libs_user_probe_$$"
+  local startup_env startup_rest
   local startup_r_libs startup_r_libs_user
-  local vanilla_r_libs vanilla_r_libs_user
-  startup_env=$(read_r_library_env)
-  vanilla_env=$(read_r_library_env --vanilla)
+  startup_env=$(read_r_library_env "${marker_r_libs}" "${marker_r_libs_user}")
   startup_r_libs="${startup_env%%"${separator}"*}"
-  startup_r_libs_user="${startup_env#*"${separator}"}"
-  vanilla_r_libs="${vanilla_env%%"${separator}"*}"
-  vanilla_r_libs_user="${vanilla_env#*"${separator}"}"
+  startup_rest="${startup_env#*"${separator}"}"
+  startup_r_libs_user="${startup_rest%%"${separator}"*}"
+  r_version="${startup_rest#*"${separator}"}"
 
   if [[ -n "${startup_r_libs}" && "${startup_r_libs}" != 'NULL' &&
-    "${startup_r_libs}" != "${vanilla_r_libs}" ]]; then
+    "${startup_r_libs}" != "${marker_r_libs}" ]]; then
     export R_LIBS="${startup_r_libs}"
     export R_LIBS_USER='NULL'
     return 0
   fi
   if [[ -n "${startup_r_libs_user}" &&
     "${startup_r_libs_user}" != 'NULL' &&
-    "${startup_r_libs_user}" != "${vanilla_r_libs_user}" ]]; then
+    "${startup_r_libs_user}" != "${marker_r_libs_user}" ]]; then
     export R_LIBS_USER="${startup_r_libs_user}"
     return 0
   fi
   return 1
 }
 
+r_version=''
 if [[ -n "${R_LIBS_USER:-}" && "${R_LIBS_USER:-}" != 'NULL' ]]; then
   :
 elif [[ -n "${R_LIBS:-}" && "${R_LIBS:-}" != 'NULL' ]]; then
@@ -58,14 +60,10 @@ elif [[ -n "${R_LIBS:-}" && "${R_LIBS:-}" != 'NULL' ]]; then
 elif use_r_startup_library; then
   :
 else
-  # shellcheck disable=SC2016
-  r_version=$(R --vanilla --slave -e '
-    cat(paste(
-      R.version$major,
-      strsplit(R.version$minor, ".", fixed = TRUE)[[1]][1],
-      sep = "."
-    ))
-  ')
+  [[ -n "${r_version}" ]] || {
+    echo 'Failed to determine the R version.' >&2
+    exit 1
+  }
   export R_LIBS_USER="${clir_root}/r/${r_version}/library"
 fi
 

--- a/bin/clir
+++ b/bin/clir
@@ -10,44 +10,124 @@ clir_root=$(realpath "$(dirname "${script_path}")/..")
 # explicit R_LIBS_USER remains authoritative; when only R_LIBS is explicit,
 # keep R from inserting its synthesized user library ahead of it.
 function read_r_library_env {
-  local marker_r_libs="${1}"
-  local marker_r_libs_user="${2}"
+  local startup_mode="${1:-normal}"
   # shellcheck disable=SC2016
-  R_LIBS="${marker_r_libs}" R_LIBS_USER="${marker_r_libs_user}" \
-    R --no-site-file --no-init-file --no-save --no-restore --no-echo --slave -e '
-      libs <- Sys.getenv(c("R_LIBS", "R_LIBS_USER"));
-      version <- paste(
-        R.version$major,
-        strsplit(R.version$minor, ".", fixed = TRUE)[[1]][1],
-        sep = "."
+  local r_code='
+    libs <- Sys.getenv(c("R_LIBS", "R_LIBS_USER"));
+    version <- paste(
+      R.version$major,
+      strsplit(R.version$minor, ".", fixed = TRUE)[[1]][1],
+      sep = "."
+    );
+    arch <- sub("^/", "", Sys.getenv("R_ARCH"));
+    env_names <- if (nzchar(arch)) {
+      c(paste0(".Renviron.", arch), ".Renviron")
+    } else {
+      ".Renviron"
+    };
+    site_file <- Sys.getenv("R_ENVIRON", unset = NA_character_);
+    site_files <- if (is.na(site_file)) {
+      candidates <- file.path(R.home("etc"), "Renviron.site");
+      if (nzchar(arch)) {
+        candidates <- c(file.path(R.home("etc"), arch, "Renviron.site"), candidates);
+      }
+      existing <- candidates[file.exists(candidates)];
+      if (length(existing)) existing[[1L]] else character()
+    } else if (nzchar(site_file)) {
+      path.expand(site_file)
+    } else {
+      character()
+    };
+    user_file <- Sys.getenv("R_ENVIRON_USER", unset = NA_character_);
+    user_files <- if (is.na(user_file)) {
+      candidates <- c(
+        file.path(getwd(), env_names),
+        file.path(path.expand("~"), env_names)
       );
-      cat(paste(c(libs, version), collapse = "\034"));
-    '
+      existing <- candidates[file.exists(candidates)];
+      if (length(existing)) existing[[1L]] else character()
+    } else if (nzchar(user_file)) {
+      path.expand(user_file)
+    } else {
+      character()
+    };
+    env_files <- unique(c(site_files, user_files));
+    has_library_assignment <- any(vapply(
+      env_files,
+      function(path) {
+        if (!file.exists(path)) return(FALSE);
+        lines <- tryCatch(readLines(path, warn = FALSE), error = function(...) character());
+        any(grepl("^[[:space:]]*(R_LIBS|R_LIBS_USER)[[:space:]]*=", lines));
+      },
+      logical(1)
+    ));
+    cat(paste(c(libs, version, as.integer(has_library_assignment)), collapse = "\034"));
+  '
+  case "${startup_mode}" in
+    'normal' )
+      # shellcheck disable=SC2016
+      env -u R_LIBS -u R_LIBS_USER \
+        R --no-site-file --no-init-file --no-save --no-restore --no-echo \
+        --slave -e "${r_code}"
+      ;;
+    'vanilla' )
+      # shellcheck disable=SC2016
+      env -u R_LIBS -u R_LIBS_USER R --vanilla --slave -e "${r_code}"
+      ;;
+    * )
+      echo "Unknown R startup probe mode: ${startup_mode}" >&2
+      return 2
+      ;;
+  esac
 }
 
 function use_r_startup_library {
   local separator=$'\034'
-  local marker_r_libs="__clir_r_libs_probe_$$"
-  local marker_r_libs_user="__clir_r_libs_user_probe_$$"
-  local startup_env startup_rest
-  local startup_r_libs startup_r_libs_user
-  startup_env=$(read_r_library_env "${marker_r_libs}" "${marker_r_libs_user}")
+  local startup_env startup_rest startup_version_rest
+  local vanilla_env vanilla_rest
+  local startup_r_libs startup_r_libs_user vanilla_r_libs vanilla_r_libs_user
+  local startup_has_library_assignment
+  startup_env=$(read_r_library_env 'normal')
   startup_r_libs="${startup_env%%"${separator}"*}"
   startup_rest="${startup_env#*"${separator}"}"
   startup_r_libs_user="${startup_rest%%"${separator}"*}"
-  r_version="${startup_rest#*"${separator}"}"
+  startup_version_rest="${startup_rest#*"${separator}"}"
+  r_version="${startup_version_rest%%"${separator}"*}"
+  startup_has_library_assignment="${startup_version_rest#*"${separator}"}"
+
+  vanilla_env=$(read_r_library_env 'vanilla')
+  vanilla_r_libs="${vanilla_env%%"${separator}"*}"
+  vanilla_rest="${vanilla_env#*"${separator}"}"
+  vanilla_r_libs_user="${vanilla_rest%%"${separator}"*}"
 
   if [[ -n "${startup_r_libs}" && "${startup_r_libs}" != 'NULL' &&
-    "${startup_r_libs}" != "${marker_r_libs}" ]]; then
+    "${startup_r_libs}" != "${vanilla_r_libs}" ]]; then
     export R_LIBS="${startup_r_libs}"
     export R_LIBS_USER='NULL'
     return 0
   fi
   if [[ -n "${startup_r_libs_user}" &&
     "${startup_r_libs_user}" != 'NULL' &&
-    "${startup_r_libs_user}" != "${marker_r_libs_user}" ]]; then
+    "${startup_r_libs_user}" != "${vanilla_r_libs_user}" ]]; then
     export R_LIBS_USER="${startup_r_libs_user}"
     return 0
+  fi
+
+  # A startup-file assignment can intentionally equal R's synthesized
+  # default. The normal probe preserves conditional expansion semantics, and
+  # the R-side assignment flag distinguishes that case from an untouched
+  # default without injecting a value into the expansion.
+  if [[ "${startup_has_library_assignment}" = 1 ]]; then
+    if [[ -n "${startup_r_libs}" && "${startup_r_libs}" != 'NULL' ]]; then
+      export R_LIBS="${startup_r_libs}"
+      export R_LIBS_USER='NULL'
+      return 0
+    fi
+    if [[ -n "${startup_r_libs_user}" &&
+      "${startup_r_libs_user}" != 'NULL' ]]; then
+      export R_LIBS_USER="${startup_r_libs_user}"
+      return 0
+    fi
   fi
   return 1
 }

--- a/install_clir.sh
+++ b/install_clir.sh
@@ -181,7 +181,6 @@ function use_r_startup_library {
   if [[ -n "${startup_r_libs}" && "${startup_r_libs}" != 'NULL' &&
     "${startup_r_libs}" != "${vanilla_r_libs}" ]]; then
     export R_LIBS="${startup_r_libs}"
-    export R_LIBS_USER='NULL'
     return 0
   fi
   if [[ -n "${startup_r_libs_user}" &&
@@ -198,7 +197,6 @@ function use_r_startup_library {
   if [[ "${startup_has_library_assignment}" = 1 ]]; then
     if [[ -n "${startup_r_libs}" && "${startup_r_libs}" != 'NULL' ]]; then
       export R_LIBS="${startup_r_libs}"
-      export R_LIBS_USER='NULL'
       return 0
     fi
     if [[ -n "${startup_r_libs_user}" &&
@@ -231,7 +229,6 @@ if [[ ${SYSTEM_INSTALL} -ne 0 ]]; then
     export R_LIBS_USER
   elif [[ -n "${R_LIBS}" && "${R_LIBS}" != 'NULL' ]]; then
     export R_LIBS
-    export R_LIBS_USER='NULL'
   else
     # Root installation must not derive a privileged library from user
     # startup files. Use the R version from an isolated probe instead.
@@ -248,9 +245,8 @@ if [[ ${SYSTEM_INSTALL} -ne 0 ]]; then
 elif [[ -n "${R_LIBS_USER}" && "${R_LIBS_USER}" != 'NULL' ]]; then
   export R_LIBS_USER
 elif [[ -n "${R_LIBS}" && "${R_LIBS}" != 'NULL' ]]; then
-  # Prevent R from synthesizing a higher-priority R_LIBS_USER path.
+  # R combines R_LIBS before R_LIBS_USER; preserve the user library.
   export R_LIBS
-  export R_LIBS_USER='NULL'
 elif use_r_startup_library; then
   :
 else
@@ -258,7 +254,6 @@ else
   export R_LIBS_USER="${CLIR_ROOT}/r/${R_VERSION}/library"
 fi
 set -u
-LIB_DIR=$(resolve_r_lib)
 
 if [[ -n "${CLIR_SOURCE_DIR:-}" ]]; then
   [[ -f "${CLIR_ROOT}/src/clir.R" ]] || abort "clir source not found: ${CLIR_ROOT}"
@@ -278,6 +273,8 @@ else
   fi
   echo
 fi
+
+LIB_DIR=$(resolve_r_lib)
 
 if [[ ${DELETE_R_LIB} -ne 0 ]]; then
   echo '>>> Delete the current clir-managed library'

--- a/install_clir.sh
+++ b/install_clir.sh
@@ -102,7 +102,7 @@ function resolve_r_lib {
 }
 
 set +u
-if [[ -n "${R_LIBS_USER}" ]]; then
+if [[ -n "${R_LIBS_USER}" && "${R_LIBS_USER}" != 'NULL' ]]; then
   export R_LIBS_USER
 elif [[ -n "${R_LIBS}" ]]; then
   # Prevent R from synthesizing a higher-priority R_LIBS_USER path.

--- a/install_clir.sh
+++ b/install_clir.sh
@@ -90,7 +90,7 @@ echo
 function resolve_r_lib {
   # shellcheck disable=SC2016
   R --vanilla --slave -e '
-    paths <- Sys.getenv(c("R_LIBS_USER", "R_LIBS"));
+    paths <- Sys.getenv(c("R_LIBS", "R_LIBS_USER"));
     paths <- paths[nzchar(paths) & paths != "NULL"];
     path <- strsplit(paths[1], .Platform$path.sep, fixed = TRUE)[[1]][1];
     path <- gsub("%V", as.character(getRversion()),
@@ -104,7 +104,7 @@ function resolve_r_lib {
 set +u
 if [[ -n "${R_LIBS_USER}" && "${R_LIBS_USER}" != 'NULL' ]]; then
   export R_LIBS_USER
-elif [[ -n "${R_LIBS}" ]]; then
+elif [[ -n "${R_LIBS}" && "${R_LIBS}" != 'NULL' ]]; then
   # Prevent R from synthesizing a higher-priority R_LIBS_USER path.
   export R_LIBS
   export R_LIBS_USER='NULL'

--- a/install_clir.sh
+++ b/install_clir.sh
@@ -43,6 +43,7 @@ SYSTEM_INSTALL=0
 REINSTALL=0
 CRAN_URL='https://cloud.r-project.org/'
 DELETE_R_LIB=0
+R_VERSION=''
 
 while [[ ${#} -ge 1 ]]; do
   case "${1}" in
@@ -87,41 +88,42 @@ git --version || abort 'Git is not found.'
 echo
 
 function read_r_library_env {
-  local startup_mode="${1:-}"
-  if [[ "${startup_mode}" = '--vanilla' ]]; then
-    # shellcheck disable=SC2016
-    R --vanilla --slave -e '
-      cat(paste(Sys.getenv(c("R_LIBS", "R_LIBS_USER")), collapse = "\034"));
-    '
-  else
-    # shellcheck disable=SC2016
+  local marker_r_libs="${1}"
+  local marker_r_libs_user="${2}"
+  # shellcheck disable=SC2016
+  R_LIBS="${marker_r_libs}" R_LIBS_USER="${marker_r_libs_user}" \
     R --no-site-file --no-init-file --no-save --no-restore --no-echo --slave -e '
-      cat(paste(Sys.getenv(c("R_LIBS", "R_LIBS_USER")), collapse = "\034"));
+      libs <- Sys.getenv(c("R_LIBS", "R_LIBS_USER"));
+      version <- paste(
+        R.version$major,
+        strsplit(R.version$minor, ".", fixed = TRUE)[[1]][1],
+        sep = "."
+      );
+      cat(paste(c(libs, version), collapse = "\034"));
     '
-  fi
 }
 
 function use_r_startup_library {
   local separator=$'\034'
-  local startup_env vanilla_env
+  local marker_r_libs="__clir_r_libs_probe_$$"
+  local marker_r_libs_user="__clir_r_libs_user_probe_$$"
+  local startup_env startup_rest
   local startup_r_libs startup_r_libs_user
-  local vanilla_r_libs vanilla_r_libs_user
-  startup_env=$(read_r_library_env)
-  vanilla_env=$(read_r_library_env --vanilla)
+  startup_env=$(read_r_library_env "${marker_r_libs}" "${marker_r_libs_user}")
   startup_r_libs="${startup_env%%"${separator}"*}"
-  startup_r_libs_user="${startup_env#*"${separator}"}"
-  vanilla_r_libs="${vanilla_env%%"${separator}"*}"
-  vanilla_r_libs_user="${vanilla_env#*"${separator}"}"
+  startup_rest="${startup_env#*"${separator}"}"
+  startup_r_libs_user="${startup_rest%%"${separator}"*}"
+  R_VERSION="${startup_rest#*"${separator}"}"
 
   if [[ -n "${startup_r_libs}" && "${startup_r_libs}" != 'NULL' &&
-    "${startup_r_libs}" != "${vanilla_r_libs}" ]]; then
+    "${startup_r_libs}" != "${marker_r_libs}" ]]; then
     export R_LIBS="${startup_r_libs}"
     export R_LIBS_USER='NULL'
     return 0
   fi
   if [[ -n "${startup_r_libs_user}" &&
     "${startup_r_libs_user}" != 'NULL' &&
-    "${startup_r_libs_user}" != "${vanilla_r_libs_user}" ]]; then
+    "${startup_r_libs_user}" != "${marker_r_libs_user}" ]]; then
     export R_LIBS_USER="${startup_r_libs_user}"
     return 0
   fi
@@ -150,14 +152,7 @@ elif [[ -n "${R_LIBS}" && "${R_LIBS}" != 'NULL' ]]; then
 elif use_r_startup_library; then
   :
 else
-  # shellcheck disable=SC2016
-  R_VERSION=$(R --vanilla --slave -e '
-    cat(paste(
-      R.version$major,
-      strsplit(R.version$minor, ".", fixed = TRUE)[[1]][1],
-      sep = "."
-    ))
-  ')
+  [[ -n "${R_VERSION}" ]] || abort 'Failed to determine the R version.'
   export R_LIBS_USER="${CLIR_ROOT}/r/${R_VERSION}/library"
 fi
 set -u

--- a/install_clir.sh
+++ b/install_clir.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Usage:
-#   install_clir.sh [--root] [-f|--force] [--cran=<url>] [--delete-r-lib] [--bioconductor]
+#   install_clir.sh [--root] [-f|--force] [--cran=<url>] [--delete-r-lib]
 #   install_clir.sh -h|--help
 #
 # Description:
@@ -11,9 +11,7 @@
 #   --root            Install clir into the system directory (/usr/local)
 #   -f, --force       Force reinstallation
 #   --cran=<url>      Set a URL for CRAN [default: https://cloud.r-project.org/]
-#   --delete-r-lib    Delete the install packages before installation
-#                     (remove `.libPaths()[[1]]`)
-#   --bioconductor    Install Bioconductor (BiocManager::install)
+#   --delete-r-lib    Delete the current clir-managed R library before installation
 #   -h, --help        Print usage
 
 set -ue
@@ -46,7 +44,6 @@ SYSTEM_INSTALL=0
 REINSTALL=0
 CRAN_URL='https://cloud.r-project.org/'
 DELETE_R_LIB=0
-BIOCONDUCTOR=0
 
 while [[ ${#} -ge 1 ]]; do
   case "${1}" in
@@ -63,13 +60,10 @@ while [[ ${#} -ge 1 ]]; do
       CRAN_URL="${2}" && shift 2
       ;;
     --cran=* )
-      CRAN_URL="${1#*\=}" && shift 1
+      CRAN_URL="${1#*=}" && shift 1
       ;;
     '--delete-r-lib' )
       DELETE_R_LIB=1 && shift 1
-      ;;
-    '--bioconductor' )
-      BIOCONDUCTOR=1 && shift 1
       ;;
     '-h' | '--help' )
       print_usage && exit 0
@@ -80,20 +74,10 @@ while [[ ${#} -ge 1 ]]; do
   esac
 done
 
-if [[ ${SYSTEM_INSTALL} -eq 0 ]]; then
+if [[ -n "${CLIR_SOURCE_DIR:-}" ]]; then
+  CLIR_ROOT=$(realpath "${CLIR_SOURCE_DIR}")
+elif [[ ${SYSTEM_INSTALL} -eq 0 ]]; then
   CLIR_ROOT="${HOME}/.clir"
-  set +u
-  if [[ -n "${R_LIBS_USER}" ]]; then
-    export R_LIBS_USER
-    LIB_DIR="${R_LIBS_USER}"
-  elif [[ -n "${R_LIBS}" ]]; then
-    export R_LIBS
-    LIB_DIR="${R_LIBS}"
-  else
-    export R_LIBS_USER="${CLIR_ROOT}/r/library"
-    LIB_DIR="${R_LIBS_USER}"
-  fi
-  set -u
 else
   CLIR_ROOT='/usr/local/src/clir'
 fi
@@ -103,75 +87,108 @@ R --version || abort 'R is not found.'
 git --version || abort 'Git is not found.'
 echo
 
-if [[ ${DELETE_R_LIB} -ne 0 ]]; then
-  echo '>>> Delete the installed packages'
-  R -q -e 'system(paste("set -ex && rm -rf ", .libPaths()[[1]], collapse = ""));'
+function resolve_r_lib {
+  # shellcheck disable=SC2016
+  R --vanilla --slave -e '
+    paths <- Sys.getenv(c("R_LIBS_USER", "R_LIBS"));
+    path <- strsplit(paths[nzchar(paths)][1], .Platform$path.sep, fixed = TRUE)[[1]][1];
+    path <- gsub("%V", as.character(getRversion()),
+      gsub("%v", paste(R.version$major,
+        strsplit(R.version$minor, ".", fixed = TRUE)[[1]][1], sep = "."),
+        path, fixed = TRUE), fixed = TRUE);
+    cat(path.expand(path));
+  '
+}
+
+if [[ ${SYSTEM_INSTALL} -eq 0 ]]; then
+  set +u
+  if [[ -n "${R_LIBS_USER}" ]]; then
+    export R_LIBS_USER
+    LIB_DIR=$(resolve_r_lib)
+  elif [[ -n "${R_LIBS}" ]]; then
+    export R_LIBS
+    LIB_DIR=$(resolve_r_lib)
+  else
+    # shellcheck disable=SC2016
+    R_VERSION=$(R --vanilla --slave -e '
+      cat(paste(
+        R.version$major,
+        strsplit(R.version$minor, ".", fixed = TRUE)[[1]][1],
+        sep = "."
+      ))
+    ')
+    export R_LIBS_USER="${CLIR_ROOT}/r/${R_VERSION}/library"
+    LIB_DIR="${R_LIBS_USER}"
+  fi
+  set -u
+else
+  LIB_DIR=$(R --vanilla --slave -e 'cat(.libPaths()[[1]])')
 fi
 
-echo '>>> Check out clir from GitHub'
-if [[ ! -d "${CLIR_ROOT}" ]]; then
-  git clone https://github.com/dceoy/clir.git "${CLIR_ROOT}"
+if [[ -n "${CLIR_SOURCE_DIR:-}" ]]; then
+  [[ -f "${CLIR_ROOT}/src/clir.R" ]] || abort "clir source not found: ${CLIR_ROOT}"
 else
-  cd "${CLIR_ROOT}" || abort "cd failed: ${CLIR_ROOT}"
-  if [[ ${REINSTALL} -eq 0 ]]; then
-    git pull --prune origin master
+  echo '>>> Check out clir from GitHub'
+  if [[ ! -d "${CLIR_ROOT}" ]]; then
+    git clone https://github.com/dceoy/clir.git "${CLIR_ROOT}"
   else
-    git fetch --prune origin master
-    git reset --hard origin/master
+    cd "${CLIR_ROOT}" || abort "cd failed: ${CLIR_ROOT}"
+    if [[ ${REINSTALL} -eq 0 ]]; then
+      git pull --prune origin master
+    else
+      git fetch --prune origin master
+      git reset --hard origin/master
+    fi
+    cd -
   fi
-  cd -
+  echo
 fi
-echo
+
+if [[ ${DELETE_R_LIB} -ne 0 ]]; then
+  echo '>>> Delete the current clir-managed library'
+  CLIR_ROOT="${CLIR_ROOT}" CLIR_LIBRARY="${LIB_DIR}" R --vanilla --slave -e '
+    source(file.path(Sys.getenv("CLIR_ROOT"), "src", "util.R"));
+    reset_clir_library(
+      target = Sys.getenv("CLIR_LIBRARY"),
+      clir_root_dir = Sys.getenv("CLIR_ROOT")
+    )
+  '
+fi
 
 echo '>>> Install dependencies'
 if [[ ${SYSTEM_INSTALL} -eq 0 ]]; then
   [[ -d "${LIB_DIR}" ]] || mkdir -p "${LIB_DIR}"
 else
-  ln -sf /usr/local/src/clir/src/clir.R /usr/local/bin/clir
+  ln -sf "${CLIR_ROOT}/src/clir.R" /usr/local/bin/clir
 fi
 cat << EOF | R --vanilla -q || abort 'Package installation failed.'
 options(repos = c(CRAN = '${CRAN_URL}'));
-bioc_install <- ${BIOCONDUCTOR};
-pkgs <- c('docopt', 'yaml', 'devtools', 'drat', 'stringr');
-if (bioc_install != 0) {
-  pkgs <- c(pkgs, 'BiocManager');
-}
-sapply(pkgs,
-       function(p) {
-         if ((${REINSTALL} != 0) || (! require(p, character.only = TRUE))) {
-           install.packages(pkgs = p, lib = .libPaths()[[1]], dependencies = TRUE, clean = TRUE);
-         };
-         library(p, character.only = TRUE);
-       });
-if (bioc_install != 0) {
-  BiocManager::install();
+pkgs <- c('docopt', 'yaml', 'pak');
+for (p in pkgs) {
+  if ((${REINSTALL} != 0) || (!requireNamespace(p, quietly = TRUE))) {
+    install.packages(
+      pkgs = p,
+      lib = .libPaths()[[1]],
+      dependencies = NA,
+      clean = TRUE
+    );
+  }
+  if (!requireNamespace(p, quietly = TRUE)) {
+    stop(paste('Loading', p, 'failed.'));
+  }
 }
 EOF
 echo
 
 echo '>>> Validate installed packages'
-"${CLIR_ROOT}/bin/clir" install ${DEBUG_FLAG} --devt=cran devtools docopt drat stringr yaml
-if [[ ${BIOCONDUCTOR} -ne 0 ]]; then
-  "${CLIR_ROOT}/bin/clir" validate ${DEBUG_FLAG} docopt yaml devtools drat stringr BiocManager
-else
-  "${CLIR_ROOT}/bin/clir" validate ${DEBUG_FLAG} docopt yaml devtools drat stringr
-fi
+"${CLIR_ROOT}/bin/clir" install ${DEBUG_FLAG} --no-upgrade docopt yaml pak
+"${CLIR_ROOT}/bin/clir" validate ${DEBUG_FLAG} docopt yaml pak
 echo
 
 echo '>>> Done.'
-# shellcheck disable=SC2016
 if [[ ${SYSTEM_INSTALL} -eq 0 ]]; then
-  echo '
-
-To access the utility, set environment variables as follows:
-
-  # Add clir/bin to ${PATH}
-  $ echo "export PATH=${HOME}/.clir/bin:${PATH}" >> ~/.bash_profile
-
-  # Add your R library path to ${R_LIBS_USER}
-  $ echo "export R_LIBS_USER=${HOME}/.clir/r/library" >> ~/.bash_profile
-
-If you use Zsh, modify `~/.zshrc` instead of `~/.bash_profile`.
-
-For more information, see https://github.com/dceoy/clir'
+  echo "Add ${CLIR_ROOT}/bin to PATH."
+  echo "The clir library is ${LIB_DIR}."
+  echo 'If you use Zsh, update ~/.zshrc; otherwise update ~/.bash_profile.'
+  echo 'For more information, see https://github.com/dceoy/clir'
 fi

--- a/install_clir.sh
+++ b/install_clir.sh
@@ -157,11 +157,13 @@ mkdir -p "${LIB_DIR}"
 if [[ ${SYSTEM_INSTALL} -ne 0 ]]; then
   ln -sf "${CLIR_ROOT}/bin/clir" /usr/local/bin/clir
 fi
-cat << EOF | R --vanilla -q || abort 'Package installation failed.'
-options(repos = c(CRAN = '${CRAN_URL}'));
+CLIR_CRAN_URL="${CRAN_URL}" CLIR_REINSTALL="${REINSTALL}" \
+  R --vanilla -q <<'EOF' || abort 'Package installation failed.'
+options(repos = c(CRAN = Sys.getenv("CLIR_CRAN_URL")));
 pkgs <- c('docopt', 'yaml', 'pak');
+reinstall <- identical(Sys.getenv("CLIR_REINSTALL"), "1");
 for (p in pkgs) {
-  if ((${REINSTALL} != 0) || (!requireNamespace(p, quietly = TRUE))) {
+  if (reinstall || (!requireNamespace(p, quietly = TRUE))) {
     install.packages(
       pkgs = p,
       lib = .libPaths()[[1]],

--- a/install_clir.sh
+++ b/install_clir.sh
@@ -88,62 +88,164 @@ git --version || abort 'Git is not found.'
 echo
 
 function read_r_library_env {
-  local marker_r_libs="${1}"
-  local marker_r_libs_user="${2}"
+  local startup_mode="${1:-normal}"
   # shellcheck disable=SC2016
-  R_LIBS="${marker_r_libs}" R_LIBS_USER="${marker_r_libs_user}" \
-    R --no-site-file --no-init-file --no-save --no-restore --no-echo --slave -e '
-      libs <- Sys.getenv(c("R_LIBS", "R_LIBS_USER"));
-      version <- paste(
-        R.version$major,
-        strsplit(R.version$minor, ".", fixed = TRUE)[[1]][1],
-        sep = "."
+  local r_code='
+    libs <- Sys.getenv(c("R_LIBS", "R_LIBS_USER"));
+    version <- paste(
+      R.version$major,
+      strsplit(R.version$minor, ".", fixed = TRUE)[[1]][1],
+      sep = "."
+    );
+    arch <- sub("^/", "", Sys.getenv("R_ARCH"));
+    env_names <- if (nzchar(arch)) {
+      c(paste0(".Renviron.", arch), ".Renviron")
+    } else {
+      ".Renviron"
+    };
+    site_file <- Sys.getenv("R_ENVIRON", unset = NA_character_);
+    site_files <- if (is.na(site_file)) {
+      candidates <- file.path(R.home("etc"), "Renviron.site");
+      if (nzchar(arch)) {
+        candidates <- c(file.path(R.home("etc"), arch, "Renviron.site"), candidates);
+      }
+      existing <- candidates[file.exists(candidates)];
+      if (length(existing)) existing[[1L]] else character()
+    } else if (nzchar(site_file)) {
+      path.expand(site_file)
+    } else {
+      character()
+    };
+    user_file <- Sys.getenv("R_ENVIRON_USER", unset = NA_character_);
+    user_files <- if (is.na(user_file)) {
+      candidates <- c(
+        file.path(getwd(), env_names),
+        file.path(path.expand("~"), env_names)
       );
-      cat(paste(c(libs, version), collapse = "\034"));
-    '
+      existing <- candidates[file.exists(candidates)];
+      if (length(existing)) existing[[1L]] else character()
+    } else if (nzchar(user_file)) {
+      path.expand(user_file)
+    } else {
+      character()
+    };
+    env_files <- unique(c(site_files, user_files));
+    has_library_assignment <- any(vapply(
+      env_files,
+      function(path) {
+        if (!file.exists(path)) return(FALSE);
+        lines <- tryCatch(readLines(path, warn = FALSE), error = function(...) character());
+        any(grepl("^[[:space:]]*(R_LIBS|R_LIBS_USER)[[:space:]]*=", lines));
+      },
+      logical(1)
+    ));
+    cat(paste(c(libs, version, as.integer(has_library_assignment)), collapse = "\034"));
+  '
+  case "${startup_mode}" in
+    'normal' )
+      # shellcheck disable=SC2016
+      env -u R_LIBS -u R_LIBS_USER \
+        R --no-site-file --no-init-file --no-save --no-restore --no-echo \
+        --slave -e "${r_code}"
+      ;;
+    'vanilla' )
+      # shellcheck disable=SC2016
+      env -u R_LIBS -u R_LIBS_USER R --vanilla --slave -e "${r_code}"
+      ;;
+    * )
+      echo "Unknown R startup probe mode: ${startup_mode}" >&2
+      return 2
+      ;;
+  esac
 }
 
 function use_r_startup_library {
   local separator=$'\034'
-  local marker_r_libs="__clir_r_libs_probe_$$"
-  local marker_r_libs_user="__clir_r_libs_user_probe_$$"
-  local startup_env startup_rest
-  local startup_r_libs startup_r_libs_user
-  startup_env=$(read_r_library_env "${marker_r_libs}" "${marker_r_libs_user}")
+  local startup_env startup_rest startup_version_rest
+  local vanilla_env vanilla_rest
+  local startup_r_libs startup_r_libs_user vanilla_r_libs vanilla_r_libs_user
+  local startup_has_library_assignment
+  startup_env=$(read_r_library_env 'normal')
   startup_r_libs="${startup_env%%"${separator}"*}"
   startup_rest="${startup_env#*"${separator}"}"
   startup_r_libs_user="${startup_rest%%"${separator}"*}"
-  R_VERSION="${startup_rest#*"${separator}"}"
+  startup_version_rest="${startup_rest#*"${separator}"}"
+  R_VERSION="${startup_version_rest%%"${separator}"*}"
+  startup_has_library_assignment="${startup_version_rest#*"${separator}"}"
+
+  vanilla_env=$(read_r_library_env 'vanilla')
+  vanilla_r_libs="${vanilla_env%%"${separator}"*}"
+  vanilla_rest="${vanilla_env#*"${separator}"}"
+  vanilla_r_libs_user="${vanilla_rest%%"${separator}"*}"
 
   if [[ -n "${startup_r_libs}" && "${startup_r_libs}" != 'NULL' &&
-    "${startup_r_libs}" != "${marker_r_libs}" ]]; then
+    "${startup_r_libs}" != "${vanilla_r_libs}" ]]; then
     export R_LIBS="${startup_r_libs}"
     export R_LIBS_USER='NULL'
     return 0
   fi
   if [[ -n "${startup_r_libs_user}" &&
     "${startup_r_libs_user}" != 'NULL' &&
-    "${startup_r_libs_user}" != "${marker_r_libs_user}" ]]; then
+    "${startup_r_libs_user}" != "${vanilla_r_libs_user}" ]]; then
     export R_LIBS_USER="${startup_r_libs_user}"
     return 0
+  fi
+
+  # A startup-file assignment can intentionally equal R's synthesized
+  # default. The normal probe preserves conditional expansion semantics, and
+  # the R-side assignment flag distinguishes that case from an untouched
+  # default without injecting a value into the expansion.
+  if [[ "${startup_has_library_assignment}" = 1 ]]; then
+    if [[ -n "${startup_r_libs}" && "${startup_r_libs}" != 'NULL' ]]; then
+      export R_LIBS="${startup_r_libs}"
+      export R_LIBS_USER='NULL'
+      return 0
+    fi
+    if [[ -n "${startup_r_libs_user}" &&
+      "${startup_r_libs_user}" != 'NULL' ]]; then
+      export R_LIBS_USER="${startup_r_libs_user}"
+      return 0
+    fi
   fi
   return 1
 }
 
 function resolve_r_lib {
-  # R expands R_LIBS_USER conversion specifiers during normal startup.
+  # Resolve conversion specifiers without loading user-controlled startup
+  # files. The shared utility keeps this in sync with src/clir.R.
   # shellcheck disable=SC2016
-  R --no-site-file --no-init-file --no-save --no-restore --no-echo --slave -e '
-    paths <- Sys.getenv(c("R_LIBS", "R_LIBS_USER"));
-    paths <- paths[nzchar(paths) & paths != "NULL"];
-    if (length(paths) == 0L) stop("No R library path is configured.");
-    path <- strsplit(paths[[1L]], .Platform$path.sep, fixed = TRUE)[[1L]][[1L]];
-    cat(normalizePath(path.expand(path), mustWork = FALSE));
+  CLIR_ROOT="${CLIR_ROOT}" R --vanilla --slave -e '
+    source(file.path(Sys.getenv("CLIR_ROOT"), "src", "util.R"));
+    env <- Sys.getenv(c("R_LIBS", "R_LIBS_USER"));
+    names(env) <- c("R_LIBS", "R_LIBS_USER");
+    cat(resolve_r_library(
+      clir_root_dir = Sys.getenv("CLIR_ROOT"),
+      env = env
+    ));
   '
 }
 
 set +u
-if [[ -n "${R_LIBS_USER}" && "${R_LIBS_USER}" != 'NULL' ]]; then
+if [[ ${SYSTEM_INSTALL} -ne 0 ]]; then
+  if [[ -n "${R_LIBS_USER}" && "${R_LIBS_USER}" != 'NULL' ]]; then
+    export R_LIBS_USER
+  elif [[ -n "${R_LIBS}" && "${R_LIBS}" != 'NULL' ]]; then
+    export R_LIBS
+    export R_LIBS_USER='NULL'
+  else
+    # Root installation must not derive a privileged library from user
+    # startup files. Use the R version from an isolated probe instead.
+    # shellcheck disable=SC2016
+    R_VERSION=$(R --vanilla --slave -e '
+      cat(paste(
+        R.version$major,
+        strsplit(R.version$minor, ".", fixed = TRUE)[[1]][1],
+        sep = "."
+      ))
+    ')
+    export R_LIBS_USER="${CLIR_ROOT}/r/${R_VERSION}/library"
+  fi
+elif [[ -n "${R_LIBS_USER}" && "${R_LIBS_USER}" != 'NULL' ]]; then
   export R_LIBS_USER
 elif [[ -n "${R_LIBS}" && "${R_LIBS}" != 'NULL' ]]; then
   # Prevent R from synthesizing a higher-priority R_LIBS_USER path.
@@ -194,7 +296,8 @@ if [[ ${SYSTEM_INSTALL} -ne 0 ]]; then
   ln -sf "${CLIR_ROOT}/bin/clir" /usr/local/bin/clir
 fi
 CLIR_CRAN_URL="${CRAN_URL}" CLIR_REINSTALL="${REINSTALL}" \
-  R --no-site-file --no-init-file --no-save --no-restore --no-echo -q <<'EOF' || abort 'Package installation failed.'
+  R --no-environ --no-site-file --no-init-file --no-save --no-restore \
+    --no-echo -q <<'EOF' || abort 'Package installation failed.'
 options(repos = c(CRAN = Sys.getenv("CLIR_CRAN_URL")));
 pkgs <- c('docopt', 'yaml', 'pak');
 reinstall <- identical(Sys.getenv("CLIR_REINSTALL"), "1");
@@ -215,8 +318,17 @@ EOF
 echo
 
 echo '>>> Validate installed packages'
-"${CLIR_ROOT}/bin/clir" install --no-upgrade docopt yaml pak
-"${CLIR_ROOT}/bin/clir" validate docopt yaml pak
+if [[ ${SYSTEM_INSTALL} -ne 0 ]]; then
+  R_ENVIRON=/dev/null R_ENVIRON_USER=/dev/null \
+    R_PROFILE=/dev/null R_PROFILE_USER=/dev/null \
+    "${CLIR_ROOT}/bin/clir" install --no-upgrade docopt yaml pak
+  R_ENVIRON=/dev/null R_ENVIRON_USER=/dev/null \
+    R_PROFILE=/dev/null R_PROFILE_USER=/dev/null \
+    "${CLIR_ROOT}/bin/clir" validate docopt yaml pak
+else
+  "${CLIR_ROOT}/bin/clir" install --no-upgrade docopt yaml pak
+  "${CLIR_ROOT}/bin/clir" validate docopt yaml pak
+fi
 echo
 
 echo '>>> Done.'

--- a/install_clir.sh
+++ b/install_clir.sh
@@ -96,7 +96,7 @@ function read_r_library_env {
     '
   else
     # shellcheck disable=SC2016
-    R --no-save --no-restore --no-echo --slave -e '
+    R --no-site-file --no-init-file --no-save --no-restore --no-echo --slave -e '
       cat(paste(Sys.getenv(c("R_LIBS", "R_LIBS_USER")), collapse = "\034"));
     '
   fi
@@ -132,7 +132,7 @@ function use_r_startup_library {
 function resolve_r_lib {
   # R expands R_LIBS_USER conversion specifiers during normal startup.
   # shellcheck disable=SC2016
-  R --no-save --no-restore --no-echo --slave -e '
+  R --no-site-file --no-init-file --no-save --no-restore --no-echo --slave -e '
     paths <- Sys.getenv(c("R_LIBS", "R_LIBS_USER"));
     paths <- paths[nzchar(paths) & paths != "NULL"];
     if (length(paths) == 0L) stop("No R library path is configured.");
@@ -200,7 +200,7 @@ if [[ ${SYSTEM_INSTALL} -ne 0 ]]; then
   ln -sf "${CLIR_ROOT}/bin/clir" /usr/local/bin/clir
 fi
 CLIR_CRAN_URL="${CRAN_URL}" CLIR_REINSTALL="${REINSTALL}" \
-  R --no-save --no-restore --no-echo -q <<'EOF' || abort 'Package installation failed.'
+  R --no-site-file --no-init-file --no-save --no-restore --no-echo -q <<'EOF' || abort 'Package installation failed.'
 options(repos = c(CRAN = Sys.getenv("CLIR_CRAN_URL")));
 pkgs <- c('docopt', 'yaml', 'pak');
 reinstall <- identical(Sys.getenv("CLIR_REINSTALL"), "1");

--- a/install_clir.sh
+++ b/install_clir.sh
@@ -87,15 +87,57 @@ R --version || abort 'R is not found.'
 git --version || abort 'Git is not found.'
 echo
 
+function read_r_library_env {
+  local startup_mode="${1:-}"
+  if [[ "${startup_mode}" = '--vanilla' ]]; then
+    # shellcheck disable=SC2016
+    R --vanilla --slave -e '
+      cat(paste(Sys.getenv(c("R_LIBS", "R_LIBS_USER")), collapse = "\034"));
+    '
+  else
+    # shellcheck disable=SC2016
+    R --no-save --no-restore --no-echo --slave -e '
+      cat(paste(Sys.getenv(c("R_LIBS", "R_LIBS_USER")), collapse = "\034"));
+    '
+  fi
+}
+
+function use_r_startup_library {
+  local separator=$'\034'
+  local startup_env vanilla_env
+  local startup_r_libs startup_r_libs_user
+  local vanilla_r_libs vanilla_r_libs_user
+  startup_env=$(read_r_library_env)
+  vanilla_env=$(read_r_library_env --vanilla)
+  startup_r_libs="${startup_env%%"${separator}"*}"
+  startup_r_libs_user="${startup_env#*"${separator}"}"
+  vanilla_r_libs="${vanilla_env%%"${separator}"*}"
+  vanilla_r_libs_user="${vanilla_env#*"${separator}"}"
+
+  if [[ -n "${startup_r_libs}" && "${startup_r_libs}" != 'NULL' &&
+    "${startup_r_libs}" != "${vanilla_r_libs}" ]]; then
+    export R_LIBS="${startup_r_libs}"
+    export R_LIBS_USER='NULL'
+    return 0
+  fi
+  if [[ -n "${startup_r_libs_user}" &&
+    "${startup_r_libs_user}" != 'NULL' &&
+    "${startup_r_libs_user}" != "${vanilla_r_libs_user}" ]]; then
+    export R_LIBS_USER="${startup_r_libs_user}"
+    return 0
+  fi
+  return 1
+}
+
 function resolve_r_lib {
+  # R expands R_LIBS_USER conversion specifiers during normal startup.
   # shellcheck disable=SC2016
-  R --vanilla --slave -e '
+  R --no-save --no-restore --no-echo --slave -e '
     paths <- Sys.getenv(c("R_LIBS", "R_LIBS_USER"));
     paths <- paths[nzchar(paths) & paths != "NULL"];
-    path <- strsplit(paths[1], .Platform$path.sep, fixed = TRUE)[[1]][1];
-    # R expands conversion specifiers for R_LIBS_USER and R_LIBS_SITE at startup;
-    # R_LIBS remains literal, matching the documented behavior.
-    cat(path.expand(path));
+    if (length(paths) == 0L) stop("No R library path is configured.");
+    path <- strsplit(paths[[1L]], .Platform$path.sep, fixed = TRUE)[[1L]][[1L]];
+    cat(normalizePath(path.expand(path), mustWork = FALSE));
   '
 }
 
@@ -106,6 +148,8 @@ elif [[ -n "${R_LIBS}" && "${R_LIBS}" != 'NULL' ]]; then
   # Prevent R from synthesizing a higher-priority R_LIBS_USER path.
   export R_LIBS
   export R_LIBS_USER='NULL'
+elif use_r_startup_library; then
+  :
 else
   # shellcheck disable=SC2016
   R_VERSION=$(R --vanilla --slave -e '
@@ -156,7 +200,7 @@ if [[ ${SYSTEM_INSTALL} -ne 0 ]]; then
   ln -sf "${CLIR_ROOT}/bin/clir" /usr/local/bin/clir
 fi
 CLIR_CRAN_URL="${CRAN_URL}" CLIR_REINSTALL="${REINSTALL}" \
-  R --vanilla -q <<'EOF' || abort 'Package installation failed.'
+  R --no-save --no-restore --no-echo -q <<'EOF' || abort 'Package installation failed.'
 options(repos = c(CRAN = Sys.getenv("CLIR_CRAN_URL")));
 pkgs <- c('docopt', 'yaml', 'pak');
 reinstall <- identical(Sys.getenv("CLIR_REINSTALL"), "1");

--- a/install_clir.sh
+++ b/install_clir.sh
@@ -91,7 +91,8 @@ function resolve_r_lib {
   # shellcheck disable=SC2016
   R --vanilla --slave -e '
     paths <- Sys.getenv(c("R_LIBS_USER", "R_LIBS"));
-    path <- strsplit(paths[nzchar(paths)][1], .Platform$path.sep, fixed = TRUE)[[1]][1];
+    paths <- paths[nzchar(paths) & paths != "NULL"];
+    path <- strsplit(paths[1], .Platform$path.sep, fixed = TRUE)[[1]][1];
     path <- gsub("%V", as.character(getRversion()),
       gsub("%v", paste(R.version$major,
         strsplit(R.version$minor, ".", fixed = TRUE)[[1]][1], sep = "."),
@@ -106,7 +107,7 @@ if [[ -n "${R_LIBS_USER}" ]]; then
 elif [[ -n "${R_LIBS}" ]]; then
   # Prevent R from synthesizing a higher-priority R_LIBS_USER path.
   export R_LIBS
-  export R_LIBS_USER=''
+  export R_LIBS_USER='NULL'
 else
   # shellcheck disable=SC2016
   R_VERSION=$(R --vanilla --slave -e '

--- a/install_clir.sh
+++ b/install_clir.sh
@@ -17,10 +17,9 @@
 set -ue
 
 SCRIPT_PATH=$(realpath "${0}")
-DEBUG_FLAG=''
 if [[ ${#} -ge 1 ]]; then
   for a in "${@}"; do
-    [[ "${a}" = '--debug' ]] && DEBUG_FLAG='-d' && set -x && break
+    [[ "${a}" = '--debug' ]] && set -x && break
   done
 fi
 
@@ -221,8 +220,8 @@ EOF
 echo
 
 echo '>>> Validate installed packages'
-"${CLIR_ROOT}/bin/clir" install ${DEBUG_FLAG} --no-upgrade docopt yaml pak
-"${CLIR_ROOT}/bin/clir" validate ${DEBUG_FLAG} docopt yaml pak
+"${CLIR_ROOT}/bin/clir" install --no-upgrade docopt yaml pak
+"${CLIR_ROOT}/bin/clir" validate docopt yaml pak
 echo
 
 echo '>>> Done.'

--- a/install_clir.sh
+++ b/install_clir.sh
@@ -100,30 +100,26 @@ function resolve_r_lib {
   '
 }
 
-if [[ ${SYSTEM_INSTALL} -eq 0 ]]; then
-  set +u
-  if [[ -n "${R_LIBS_USER}" ]]; then
-    export R_LIBS_USER
-    LIB_DIR=$(resolve_r_lib)
-  elif [[ -n "${R_LIBS}" ]]; then
-    export R_LIBS
-    LIB_DIR=$(resolve_r_lib)
-  else
-    # shellcheck disable=SC2016
-    R_VERSION=$(R --vanilla --slave -e '
-      cat(paste(
-        R.version$major,
-        strsplit(R.version$minor, ".", fixed = TRUE)[[1]][1],
-        sep = "."
-      ))
-    ')
-    export R_LIBS_USER="${CLIR_ROOT}/r/${R_VERSION}/library"
-    LIB_DIR="${R_LIBS_USER}"
-  fi
-  set -u
+set +u
+if [[ -n "${R_LIBS_USER}" ]]; then
+  export R_LIBS_USER
+elif [[ -n "${R_LIBS}" ]]; then
+  # Prevent R from synthesizing a higher-priority R_LIBS_USER path.
+  export R_LIBS
+  export R_LIBS_USER=''
 else
-  LIB_DIR=$(R --vanilla --slave -e 'cat(.libPaths()[[1]])')
+  # shellcheck disable=SC2016
+  R_VERSION=$(R --vanilla --slave -e '
+    cat(paste(
+      R.version$major,
+      strsplit(R.version$minor, ".", fixed = TRUE)[[1]][1],
+      sep = "."
+    ))
+  ')
+  export R_LIBS_USER="${CLIR_ROOT}/r/${R_VERSION}/library"
 fi
+set -u
+LIB_DIR=$(resolve_r_lib)
 
 if [[ -n "${CLIR_SOURCE_DIR:-}" ]]; then
   [[ -f "${CLIR_ROOT}/src/clir.R" ]] || abort "clir source not found: ${CLIR_ROOT}"
@@ -156,10 +152,9 @@ if [[ ${DELETE_R_LIB} -ne 0 ]]; then
 fi
 
 echo '>>> Install dependencies'
-if [[ ${SYSTEM_INSTALL} -eq 0 ]]; then
-  [[ -d "${LIB_DIR}" ]] || mkdir -p "${LIB_DIR}"
-else
-  ln -sf "${CLIR_ROOT}/src/clir.R" /usr/local/bin/clir
+mkdir -p "${LIB_DIR}"
+if [[ ${SYSTEM_INSTALL} -ne 0 ]]; then
+  ln -sf "${CLIR_ROOT}/bin/clir" /usr/local/bin/clir
 fi
 cat << EOF | R --vanilla -q || abort 'Package installation failed.'
 options(repos = c(CRAN = '${CRAN_URL}'));

--- a/install_clir.sh
+++ b/install_clir.sh
@@ -93,10 +93,7 @@ function resolve_r_lib {
     paths <- Sys.getenv(c("R_LIBS", "R_LIBS_USER"));
     paths <- paths[nzchar(paths) & paths != "NULL"];
     path <- strsplit(paths[1], .Platform$path.sep, fixed = TRUE)[[1]][1];
-    path <- gsub("%V", as.character(getRversion()),
-      gsub("%v", paste(R.version$major,
-        strsplit(R.version$minor, ".", fixed = TRUE)[[1]][1], sep = "."),
-        path, fixed = TRUE), fixed = TRUE);
+    # R expands all supported library conversion specifiers at startup.
     cat(path.expand(path));
   '
 }

--- a/install_clir.sh
+++ b/install_clir.sh
@@ -93,7 +93,8 @@ function resolve_r_lib {
     paths <- Sys.getenv(c("R_LIBS", "R_LIBS_USER"));
     paths <- paths[nzchar(paths) & paths != "NULL"];
     path <- strsplit(paths[1], .Platform$path.sep, fixed = TRUE)[[1]][1];
-    # R expands all supported library conversion specifiers at startup.
+    # R expands conversion specifiers for R_LIBS_USER and R_LIBS_SITE at startup;
+    # R_LIBS remains literal, matching the documented behavior.
     cat(path.expand(path));
   '
 }

--- a/src/clir.R
+++ b/src/clir.R
@@ -40,7 +40,7 @@ Arguments:
     <url>...            A CRAN repository URL
     <pkg>...            R package names or pak package references"
 
-clir_version <- "v1.2.1"
+clir_version <- "v2.0.0"
 
 fetch_clir_root <- function() {
   ca <- commandArgs(trailingOnly = FALSE)

--- a/src/clir.R
+++ b/src/clir.R
@@ -61,7 +61,7 @@ fetch_clir_root <- function() {
   }
 }
 
-main <- function(args, clir_root_dir = fetch_clir_root(), r_lib = NULL) {
+initialize_clir <- function(clir_root_dir = fetch_clir_root(), r_lib = NULL) {
   clir_root_dir <- normalizePath(path.expand(clir_root_dir), mustWork = FALSE)
   util <- source(file.path(clir_root_dir, "src/util.R"))
   startup_env <- Sys.getenv(c("CLIR_R_LIBS", "CLIR_R_LIBS_USER"))
@@ -80,6 +80,24 @@ main <- function(args, clir_root_dir = fetch_clir_root(), r_lib = NULL) {
   }
   make_clir_dirs(clir_root_dir = clir_root_dir, r_lib = r_lib)
   .libPaths(unique(c(r_lib, .libPaths())))
+  list(
+    clir_root_dir = clir_root_dir,
+    r_lib = r_lib,
+    util = util$value
+  )
+}
+
+main <- function(args, clir_root_dir = fetch_clir_root(), r_lib = NULL,
+                 initialized = NULL) {
+  if (is.null(initialized)) {
+    initialized <- initialize_clir(
+      clir_root_dir = clir_root_dir,
+      r_lib = r_lib
+    )
+  }
+  clir_root_dir <- initialized$clir_root_dir
+  r_lib <- initialized$r_lib
+  util <- initialized$util
   ncpus <- ifelse(
     is.null(args[["--cpus"]]),
     parallel::detectCores(),
@@ -97,7 +115,7 @@ main <- function(args, clir_root_dir = fetch_clir_root(), r_lib = NULL) {
       character.only = TRUE,
       quietly = (!args[["-v"]])
     ),
-    src = util$value
+    src = util
   )
   clir_yml <- file.path(clir_root_dir, "r/clir.yml")
   repos <- load_repos(clir_yml = clir_yml, quiet = args[["--quiet"]])
@@ -148,10 +166,11 @@ main <- function(args, clir_root_dir = fetch_clir_root(), r_lib = NULL) {
 }
 
 if (!interactive()) {
+  initialized <- initialize_clir()
   args <- docopt::docopt(doc, version = clir_version)
   if (args[["--quiet"]]) {
-    suppressMessages(main(args = args))
+    suppressMessages(main(args = args, initialized = initialized))
   } else {
-    main(args = args)
+    main(args = args, initialized = initialized)
   }
 }

--- a/src/clir.R
+++ b/src/clir.R
@@ -6,9 +6,8 @@ R Package Installer for Command Line Interface
 Usage:
     clir config [-v] [--quiet] [--init]
     clir cran [-v] [--quiet] [--list] [<url>...]
-    clir drat [-v] [--quiet] <repo>...
-    clir update [-v] [--quiet] [--bioc] [--cpus=<int>]
-    clir install [-v] [--quiet] [--devt=<type>|--bioc] [--no-upgrade] [--cpus=<int>] <pkg>...
+    clir update [-v] [--quiet] [--cpus=<int>]
+    clir install [-v] [--quiet] [--no-upgrade] [--cpus=<int>] <pkg>...
     clir download [-v] [--quiet] [--dest-dir=<path>] <pkg>...
     clir uninstall [-v] [--quiet] <pkg>...
     clir validate [-v] [--quiet] <pkg>...
@@ -19,11 +18,8 @@ Usage:
 Options:
     --init              Initialize configurations for clir
     --list              List URLs of CRAN mirrors
-    --devt=<type>       Use `devtools::install_<type>`
-                        [choices: cran, github, bitbucket, bioc]
-    --bioc              Use BiocManager::install
-    --no-upgrade        Skip upgrade of old R packages
-    --cpus=<int>        Specify Ncpus
+    --no-upgrade        Skip upgrade of already installed packages
+    --cpus=<int>        Specify the number of package build CPUs
     --dest-dir=<path>   Set a destination directory [default: .]
     --quiet             Suppress messages
     -v                  Execute a command with verbose messages
@@ -32,29 +28,27 @@ Options:
 
 Commands:
     config              Print configurations for clir
-    cran                Set URLs of CRAN mirror sites
-    drat                Set Drat repositories
-    update              Update installed R packages via CRAN or Bioconductor
-    install             Install or update R packages
+    cran                Set the CRAN repository URL
+    update              Update installed R packages via pak
+    install             Install or update R package references via pak
     download            Download R packages from CRAN
     uninstall           Uninstall R packages
     validate            Load R packages to validate their installation
-    session             Print session infomation
+    session             Print session information
 
 Arguments:
-    <url>...            URLs of CRAN mirrors
-    <repo>...           Drat repository names
-    <pkg>...            R package names"
+    <url>...            A CRAN repository URL
+    <pkg>...            R package names or pak package references"
 
 clir_version <- "v1.2.1"
 
 fetch_clir_root <- function() {
   ca <- commandArgs(trailingOnly = FALSE)
   fa <- ca[grepl("^--file=", ca)]
-  if (length(fa) == 1) {
+  if (length(fa) == 1L) {
     f <- sub("--file=", "", fa)
     l <- Sys.readlink(f)
-    if (is.na(l)) {
+    if (is.na(l) || !nzchar(l)) {
       cmd_path <- normalizePath(f)
     } else if (startsWith(l, "/")) {
       cmd_path <- normalizePath(l)
@@ -67,10 +61,14 @@ fetch_clir_root <- function() {
   }
 }
 
-main <- function(args, clir_root_dir = fetch_clir_root(),
-                 r_lib = .libPaths()[1]) {
-  ncpus <- ifelse(is.null(args[["--cpus"]]),
-    parallel::detectCores(), as.integer(args[["--cpus"]])
+main <- function(args, clir_root_dir = fetch_clir_root(), r_lib = NULL) {
+  clir_root_dir <- normalizePath(path.expand(clir_root_dir), mustWork = FALSE)
+  util <- source(file.path(clir_root_dir, "src/util.R"))
+  r_lib <- resolve_r_library(clir_root_dir = clir_root_dir, r_lib = r_lib)
+  ncpus <- ifelse(
+    is.null(args[["--cpus"]]),
+    parallel::detectCores(),
+    as.integer(args[["--cpus"]])
   )
   options(warn = 1, Ncpus = ncpus, verbose = args[["-v"]])
   if (args[["-v"]]) {
@@ -78,48 +76,51 @@ main <- function(args, clir_root_dir = fetch_clir_root(),
   }
   loaded <- list(
     args = args,
-    pkg = sapply(c("devtools", "drat", "stringr", "yaml"),
+    pkg = sapply(
+      c("pak", "yaml"),
       require,
       character.only = TRUE,
       quietly = (!args[["-v"]])
     ),
-    src = source(file.path(clir_root_dir, "src/util.R"))
+    src = util$value
   )
-  make_clir_dirs(clir_root_dir = clir_root_dir)
+  make_clir_dirs(clir_root_dir = clir_root_dir, r_lib = r_lib)
   clir_yml <- file.path(clir_root_dir, "r/clir.yml")
   repos <- load_repos(clir_yml = clir_yml, quiet = args[["--quiet"]])
   options(repos = repos)
   if (args[["-v"]]) {
-    print(c(loaded, sapply(c("repos"), getOption)))
+    print(c(loaded, list(repos = repos)))
   }
   if (args[["config"]]) {
     print_config(clir_yml = clir_yml, r_lib = r_lib, init = args[["--init"]])
   } else if (args[["cran"]]) {
     if (args[["--list"]]) {
       print_cran_mirrors(https = TRUE)
-    } else if (length(args[["<url>"]]) > 0) {
-      add_config(new = args[["<url>"]], key = "cran_urls", clir_yml = clir_yml)
+    } else if (length(args[["<url>"]]) > 0L) {
+      add_config(new = args[["<url>"]], key = "repos", clir_yml = clir_yml)
     } else {
-      stop("URLs or --list must be passed for this command.")
+      stop("A URL or --list must be passed for this command.")
     }
-  } else if (args[["drat"]]) {
-    add_config(new = args[["<repo>"]], key = "drat_repos", clir_yml = clir_yml)
   } else if (args[["update"]]) {
     update_pkgs(
-      repos = repos, r_lib = r_lib, bioc = args[["--bioc"]],
+      repos = repos,
+      r_lib = r_lib,
       quiet = args[["--quiet"]]
     )
   } else if (args[["install"]]) {
     install_pkgs(
-      pkgs = args[["<pkg>"]], repos = repos,
-      bioc = args[["--bioc"]], devt = args[["--devt"]],
-      r_lib = r_lib, upgrade = (!args[["--no-upgrade"]]),
+      pkgs = args[["<pkg>"]],
+      repos = repos,
+      r_lib = r_lib,
+      upgrade = (!args[["--no-upgrade"]]),
       quiet = args[["--quiet"]]
     )
   } else if (args[["download"]]) {
     download.packages(
-      pkgs = args[["<pkg>"]], destdir = args[["--dest-dir"]],
-      repos = repos, type = "source"
+      pkgs = args[["<pkg>"]],
+      destdir = args[["--dest-dir"]],
+      repos = repos,
+      type = "source"
     )
   } else if (args[["uninstall"]]) {
     remove.packages(pkgs = args[["<pkg>"]], lib = r_lib)

--- a/src/clir.R
+++ b/src/clir.R
@@ -64,7 +64,22 @@ fetch_clir_root <- function() {
 main <- function(args, clir_root_dir = fetch_clir_root(), r_lib = NULL) {
   clir_root_dir <- normalizePath(path.expand(clir_root_dir), mustWork = FALSE)
   util <- source(file.path(clir_root_dir, "src/util.R"))
-  r_lib <- resolve_r_library(clir_root_dir = clir_root_dir, r_lib = r_lib)
+  startup_env <- Sys.getenv(c("CLIR_R_LIBS", "CLIR_R_LIBS_USER"))
+  names(startup_env) <- c("R_LIBS", "R_LIBS_USER")
+  if (is.null(r_lib)) {
+    if (any(nzchar(startup_env))) {
+      r_lib <- resolve_r_library(
+        clir_root_dir = clir_root_dir,
+        env = startup_env
+      )
+    } else {
+      r_lib <- normalizePath(.libPaths()[[1L]], mustWork = FALSE)
+    }
+  } else {
+    r_lib <- resolve_r_library(clir_root_dir = clir_root_dir, r_lib = r_lib)
+  }
+  make_clir_dirs(clir_root_dir = clir_root_dir, r_lib = r_lib)
+  .libPaths(unique(c(r_lib, .libPaths())))
   ncpus <- ifelse(
     is.null(args[["--cpus"]]),
     parallel::detectCores(),
@@ -84,7 +99,6 @@ main <- function(args, clir_root_dir = fetch_clir_root(), r_lib = NULL) {
     ),
     src = util$value
   )
-  make_clir_dirs(clir_root_dir = clir_root_dir, r_lib = r_lib)
   clir_yml <- file.path(clir_root_dir, "r/clir.yml")
   repos <- load_repos(clir_yml = clir_yml, quiet = args[["--quiet"]])
   options(repos = repos)

--- a/src/util.R
+++ b/src/util.R
@@ -224,14 +224,14 @@ repo_fallback_names <- function(n, existing = character()) {
   }
   existing <- as.character(existing)
   existing <- existing[!is.na(existing) & nzchar(existing)]
-  used <- existing
+  used <- tolower(existing)
   result <- character(n)
   for (index in seq_len(n)) {
-    if (index == 1L && !"CRAN" %in% used) {
+    if (index == 1L && !"cran" %in% used) {
       candidate <- "CRAN"
     } else {
       candidate <- "repository1"
-      while (candidate %in% used) {
+      while (tolower(candidate) %in% used) {
         candidate <- paste0(
           "repository",
           as.integer(sub("^repository", "", candidate)) + 1L
@@ -239,7 +239,7 @@ repo_fallback_names <- function(n, existing = character()) {
       }
     }
     result[[index]] <- candidate
-    used <- c(used, candidate)
+    used <- c(used, tolower(candidate))
   }
   result
 }
@@ -288,7 +288,7 @@ normalize_repos <- function(config) {
     repo_names <- names(repos)
   }
   names(repos) <- repo_names
-  repos[!duplicated(names(repos))]
+  repos[!duplicated(tolower(names(repos)))]
 }
 
 normalize_config <- function(config) {
@@ -340,22 +340,27 @@ add_config <- function(new, key, clir_yml) {
 
   config <- normalize_config(read_config(clir_yml))
   if (key %in% c("repos", "cran_urls")) {
+    existing_names <- names(config$repos)
+    existing_names <- existing_names[tolower(existing_names) != "cran"]
     if (is.null(new_names) || length(new_names) != length(new)) {
-      new_names <- repo_fallback_names(length(new))
+      new_names <- repo_fallback_names(
+        length(new),
+        existing = existing_names
+      )
     } else {
       missing_names <- is.na(new_names) | !nzchar(new_names)
       if (any(missing_names)) {
         new_names[missing_names] <- repo_fallback_names(
           sum(missing_names),
-          existing = new_names[!missing_names]
+          existing = c(existing_names, new_names[!missing_names])
         )
       }
       new_names[tolower(new_names) == "cran"] <- "CRAN"
     }
     names(new) <- new_names
-    new <- new[!duplicated(names(new))]
+    new <- new[!duplicated(tolower(names(new)))]
     repos <- c(new, config$repos)
-    config <- list(repos = repos[!duplicated(names(repos))])
+    config <- list(repos = repos[!duplicated(tolower(names(repos)))])
   } else {
     old <- read_config(clir_yml)[[key]]
     config[[key]] <- unique(c(new, as.character(old)))
@@ -435,13 +440,18 @@ canonical_ref <- function(ref) {
     return(ref)
   }
   if (grepl("^github::", ref, ignore.case = TRUE)) {
-    return(paste0("github::", sub("^github::", "", ref, ignore.case = TRUE)))
+    ref <- sub("^github::", "", ref, ignore.case = TRUE)
+    ref <- sub("/+$", "", ref)
+    return(paste0("github::", ref))
   }
   if (grepl("^https?://github\\.com/", ref, ignore.case = TRUE)) {
     ref <- sub("^https?://github\\.com/", "", ref, ignore.case = TRUE)
+    ref <- sub("/+$", "", ref)
+    ref <- sub("/releases/tag/", "@", ref, fixed = TRUE)
     ref <- sub("/(tree|commit)/", "@", ref)
     ref <- sub("/pull/", "#", ref)
     ref <- sub("\\.git$", "", ref)
+    ref <- sub("/+$", "", ref)
     return(paste0("github::", ref))
   }
   if (grepl("^git@github\\.com:", ref, ignore.case = TRUE)) {
@@ -572,7 +582,7 @@ installed_package_refs <- function(status, fallback = character()) {
 }
 
 repository_identity <- function(value) {
-  value <- tolower(trimws(as.character(value)))
+  value <- trimws(as.character(value))
   sub("/+$", "", value)
 }
 
@@ -613,16 +623,28 @@ merge_update_repos <- function(repos, status) {
     return(repos)
   }
 
-  repos <- as.character(repos)
   repo_names <- names(repos)
+  repos <- as.character(repos)
   if (is.null(repo_names) || length(repo_names) != length(repos)) {
     repo_names <- repo_fallback_names(length(repos))
   }
   for (source in sources) {
     source_key <- repository_identity(source)
+    source_is_url <- grepl(
+      "^(?:[[:alnum:]][[:alnum:].+-]*://|git@)",
+      source,
+      perl = TRUE
+    )
+    name_matches <- if (source_is_url) {
+      !is.na(repo_names) & repository_identity(repo_names) == source_key
+    } else {
+      !is.na(repo_names) &
+        tolower(trimws(repo_names)) == tolower(trimws(source))
+    }
+    value_matches <- !is.na(repos) &
+      repository_identity(repos) == source_key
     matches <- which(
-      repository_identity(repo_names) == source_key |
-        repository_identity(repos) == source_key
+      name_matches | value_matches
     )
     if (length(matches) == 0L) {
       next
@@ -695,7 +717,6 @@ update_pkgs <- function(repos, r_lib = .libPaths()[1L],
         status,
         fallback = installed_names
       )
-      repos <- merge_update_repos(repos, status)
     } else {
       installed_pkgs <- installed_names
     }

--- a/src/util.R
+++ b/src/util.R
@@ -18,12 +18,24 @@ default_r_library <- function(clir_root_dir, r_version = getRversion()) {
 }
 
 expand_r_library_tokens <- function(path, r_version = getRversion()) {
-  version <- as.character(r_version)
-  gsub(
-    "%V", version,
-    gsub("%v", r_major_minor(r_version), path, fixed = TRUE),
-    fixed = TRUE
+  if (length(path) != 1L || is.na(path)) {
+    stop("path must be one non-missing value.")
+  }
+  values <- c(
+    "%V" = as.character(r_version),
+    "%v" = r_major_minor(r_version),
+    "%p" = R.version$platform,
+    "%o" = R.version$os,
+    "%a" = R.version$arch,
+    "%U" = Sys.getenv("R_LIBS_USER"),
+    "%S" = Sys.getenv("R_LIBS_SITE")
   )
+  placeholder <- "\u0001"
+  path <- gsub("%%", placeholder, path, fixed = TRUE)
+  for (token in names(values)) {
+    path <- gsub(token, values[[token]], path, fixed = TRUE)
+  }
+  gsub(placeholder, "%", path, fixed = TRUE)
 }
 
 resolve_r_library <- function(clir_root_dir, r_version = getRversion(),
@@ -291,6 +303,10 @@ package_ref_name <- function(ref) {
   sub("\\.git$", "", ref)
 }
 
+is_plain_package_ref <- function(ref) {
+  grepl("^[A-Za-z][A-Za-z0-9.]*$", ref)
+}
+
 filter_installed_pkgs <- function(pkgs, r_lib, installed_fn,
                                   status_fn = NULL) {
   if (!is.function(installed_fn)) {
@@ -315,7 +331,11 @@ filter_installed_pkgs <- function(pkgs, r_lib, installed_fn,
     )
   }
   requested_names <- package_ref_name(pkgs)
-  keep <- !(requested_names %in% installed_names | pkgs %in% installed_refs)
+  plain_refs <- is_plain_package_ref(pkgs)
+  keep <- !(
+    (plain_refs & requested_names %in% installed_names) |
+      pkgs %in% installed_refs
+  )
   pkgs[keep]
 }
 

--- a/src/util.R
+++ b/src/util.R
@@ -17,25 +17,69 @@ default_r_library <- function(clir_root_dir, r_version = getRversion()) {
   file.path(root, "r", r_major_minor(r_version), "library")
 }
 
+r_default_user_library <- function(r_version = getRversion()) {
+  system_info <- Sys.info()
+  home <- normalizePath("~", mustWork = FALSE)
+  if (
+    identical(.Platform$OS.type, "windows") &&
+      identical(system_info[["machine"]], "x86-64")
+  ) {
+    file.path(
+      Sys.getenv("LOCALAPPDATA"),
+      "R",
+      "win-library",
+      r_major_minor(r_version)
+    )
+  } else if (identical(.Platform$OS.type, "windows")) {
+    file.path(
+      Sys.getenv("LOCALAPPDATA"),
+      "R",
+      paste0(system_info[["machine"]], "-library"),
+      r_major_minor(r_version)
+    )
+  } else if (identical(system_info[["sysname"]], "Darwin")) {
+    file.path(
+      home,
+      "Library",
+      "R",
+      system_info[["machine"]],
+      r_major_minor(r_version),
+      "library"
+    )
+  } else {
+    file.path(
+      home,
+      "R",
+      paste0(R.version$platform, "-library"),
+      r_major_minor(r_version)
+    )
+  }
+}
+
+r_default_site_library <- function() {
+  file.path(R.home(), "site-library")
+}
+
 expand_r_library_tokens <- function(path, r_version = getRversion()) {
   if (length(path) != 1L || is.na(path)) {
     stop("path must be one non-missing value.")
   }
-  values <- c(
-    "%V" = as.character(r_version),
-    "%v" = r_major_minor(r_version),
-    "%p" = R.version$platform,
-    "%o" = R.version$os,
-    "%a" = R.version$arch,
-    "%U" = Sys.getenv("R_LIBS_USER"),
-    "%S" = Sys.getenv("R_LIBS_SITE")
-  )
-  placeholder <- "\u0001"
-  path <- gsub("%%", placeholder, path, fixed = TRUE)
-  for (token in names(values)) {
-    path <- gsub(token, values[[token]], path, fixed = TRUE)
+  version <- as.character(r_version)
+  expand <- function(value, spec, expansion) {
+    replacement <- sprintf(
+      "\\1\\2%s",
+      gsub("([\\])", "\\\\\\1", expansion)
+    )
+    gsub(paste0("(^|[^%])(%%)*%", spec), replacement, value)
   }
-  gsub(placeholder, "%", path, fixed = TRUE)
+  path <- expand(path, "V", version)
+  path <- expand(path, "v", r_major_minor(r_version))
+  path <- expand(path, "p", R.version$platform)
+  path <- expand(path, "a", R.version$arch)
+  path <- expand(path, "o", R.version$os)
+  path <- expand(path, "U", r_default_user_library(r_version))
+  path <- expand(path, "S", r_default_site_library())
+  gsub("%%", "%", path, fixed = TRUE)
 }
 
 resolve_r_library <- function(clir_root_dir, r_version = getRversion(),
@@ -61,8 +105,11 @@ resolve_r_library <- function(clir_root_dir, r_version = getRversion(),
   if (length(overrides) > 0L) {
     # R accepts a path list in these variables. The first entry is the
     # library used by clir, matching .libPaths()[[1]].
+    override_name <- names(overrides)[[1L]]
     path <- strsplit(overrides[[1L]], .Platform$path.sep, fixed = TRUE)[[1L]][1L]
-    path <- expand_r_library_tokens(path, r_version = r_version)
+    if (identical(override_name, "R_LIBS_USER")) {
+      path <- expand_r_library_tokens(path, r_version = r_version)
+    }
     return(normalizePath(path.expand(path), mustWork = FALSE))
   }
 
@@ -266,9 +313,19 @@ add_config <- function(new, key, clir_yml) {
   config <- normalize_config(read_config(clir_yml))
   if (key %in% c("repos", "cran_urls")) {
     if (is.null(new_names)) {
-      new_names <- rep("CRAN", length(new))
+      new_names <- c(
+        "CRAN",
+        paste0("repository", seq_len(max(0L, length(new) - 1L)))
+      )
     } else {
-      new_names[is.na(new_names) | !nzchar(new_names)] <- "CRAN"
+      missing_names <- is.na(new_names) | !nzchar(new_names)
+      if (any(missing_names)) {
+        replacements <- c(
+          "CRAN",
+          paste0("repository", seq_len(max(0L, length(new) - 1L)))
+        )
+        new_names[missing_names] <- replacements[seq_len(sum(missing_names))]
+      }
       new_names[tolower(new_names) == "cran"] <- "CRAN"
     }
     names(new) <- new_names

--- a/src/util.R
+++ b/src/util.R
@@ -554,14 +554,20 @@ status_repositories <- function(status) {
     repositories <- rep(NA_character_, nrow(status))
   }
   repositories <- as.character(repositories)
+  missing <- is.na(repositories) | !nzchar(repositories)
+  cran_markers <- !missing &
+    tolower(repositories) %in% c("cran", "@cran@")
   for (column in c("remoterepos", "RemoteRepos")) {
     values <- status[[column]]
     if (is.null(values)) {
       next
     }
     values <- as.character(values)
-    missing <- is.na(repositories) | !nzchar(repositories)
-    repositories[missing] <- values[missing]
+    available <- !is.na(values) & nzchar(values)
+    replace <- available & (missing | cran_markers)
+    repositories[replace] <- values[replace]
+    missing[replace] <- FALSE
+    cran_markers[replace] <- FALSE
   }
   repositories
 }

--- a/src/util.R
+++ b/src/util.R
@@ -218,14 +218,30 @@ reset_clir_library <- function(target, clir_root_dir,
   invisible(TRUE)
 }
 
-repo_fallback_names <- function(n) {
+repo_fallback_names <- function(n, existing = character()) {
   if (n == 0L) {
     return(character())
   }
-  c(
-    "CRAN",
-    if (n > 1L) paste0("repository", seq_len(n - 1L)) else character()
-  )
+  existing <- as.character(existing)
+  existing <- existing[!is.na(existing) & nzchar(existing)]
+  used <- existing
+  result <- character(n)
+  for (index in seq_len(n)) {
+    if (index == 1L && !"CRAN" %in% used) {
+      candidate <- "CRAN"
+    } else {
+      candidate <- "repository1"
+      while (candidate %in% used) {
+        candidate <- paste0(
+          "repository",
+          as.integer(sub("^repository", "", candidate)) + 1L
+        )
+      }
+    }
+    result[[index]] <- candidate
+    used <- c(used, candidate)
+  }
+  result
 }
 
 normalize_repos <- function(config) {
@@ -261,8 +277,10 @@ normalize_repos <- function(config) {
   }
   missing_names <- is.na(repo_names) | !nzchar(repo_names)
   if (any(missing_names)) {
-    replacements <- repo_fallback_names(length(repos))
-    repo_names[missing_names] <- replacements[seq_len(sum(missing_names))]
+    repo_names[missing_names] <- repo_fallback_names(
+      sum(missing_names),
+      existing = repo_names[!missing_names]
+    )
   }
   repo_names[tolower(repo_names) == "cran"] <- "CRAN"
   if (!any(repo_names == "CRAN")) {
@@ -327,8 +345,10 @@ add_config <- function(new, key, clir_yml) {
     } else {
       missing_names <- is.na(new_names) | !nzchar(new_names)
       if (any(missing_names)) {
-        replacements <- repo_fallback_names(length(new))
-        new_names[missing_names] <- replacements[seq_len(sum(missing_names))]
+        new_names[missing_names] <- repo_fallback_names(
+          sum(missing_names),
+          existing = new_names[!missing_names]
+        )
       }
       new_names[tolower(new_names) == "cran"] <- "CRAN"
     }
@@ -368,7 +388,7 @@ is_plain_package_ref <- function(ref) {
   grepl("^[A-Za-z][A-Za-z0-9.]*$", ref)
 }
 
-installed_standard_package_refs <- function(status) {
+standard_installed_refs <- function(status) {
   if (is.null(status) || !is.data.frame(status) || nrow(status) == 0L) {
     return(character())
   }
@@ -394,17 +414,49 @@ installed_standard_package_refs <- function(status) {
     repositories <- rep(NA_character_, length(packages))
   }
   repositories <- as.character(repositories)
-  standard <- !use_remote & repotypes %in% c("cran", "standard")
+  standard <- !use_remote & (
+    repotypes %in% c("cran", "standard", "bioc") |
+      (!is.na(repositories) & nzchar(repositories))
+  )
   if (!any(standard)) {
     return(character())
   }
   refs <- paste0("standard::", packages[standard])
-  cran <- standard & (
+  cran <- standard & repotypes %in% c("cran", "standard") & (
     is.na(repositories) |
       !nzchar(repositories) |
       tolower(repositories) %in% c("cran", "@cran@")
   )
   unique(c(refs, paste0("cran::", packages[cran])))
+}
+
+canonical_ref <- function(ref) {
+  if (length(ref) != 1L || is.na(ref) || !nzchar(ref)) {
+    return(ref)
+  }
+  if (grepl("^github::", ref, ignore.case = TRUE)) {
+    return(paste0("github::", sub("^github::", "", ref, ignore.case = TRUE)))
+  }
+  if (grepl("^https?://github\\.com/", ref, ignore.case = TRUE)) {
+    ref <- sub("^https?://github\\.com/", "", ref, ignore.case = TRUE)
+    ref <- sub("/(tree|commit)/", "@", ref)
+    ref <- sub("/pull/", "#", ref)
+    ref <- sub("\\.git$", "", ref)
+    return(paste0("github::", ref))
+  }
+  if (grepl("^git@github\\.com:", ref, ignore.case = TRUE)) {
+    ref <- sub("^git@github\\.com:", "", ref, ignore.case = TRUE)
+    ref <- sub("\\.git$", "", ref)
+    return(paste0("github::", ref))
+  }
+  if (grepl(
+    "^[^/:[:space:]]+/[^/:[:space:]]+(/[^/:[:space:]]+)*(?:[@#].*)?$",
+    ref,
+    perl = TRUE
+  )) {
+    return(paste0("github::", ref))
+  }
+  ref
 }
 
 filter_installed_pkgs <- function(pkgs, r_lib, installed_fn,
@@ -425,15 +477,17 @@ filter_installed_pkgs <- function(pkgs, r_lib, installed_fn,
     status <- status_fn(pkg = installed_names, lib = r_lib)
     installed_refs <- c(
       installed_refs,
-      installed_standard_package_refs(status),
+      standard_installed_refs(status),
       installed_package_refs(status, fallback = installed_names)
     )
   }
   requested_names <- package_ref_name(pkgs)
   plain_refs <- is_plain_package_ref(pkgs)
+  requested_refs <- vapply(pkgs, canonical_ref, character(1))
+  installed_refs <- vapply(installed_refs, canonical_ref, character(1))
   keep <- !(
     (plain_refs & requested_names %in% installed_names) |
-      pkgs %in% installed_refs
+      requested_refs %in% installed_refs
   )
   pkgs[keep]
 }
@@ -485,13 +539,13 @@ install_pkgs <- function(pkgs, repos, r_lib = .libPaths()[1L],
   invisible(result)
 }
 
-installed_package_refs <- function(status, fallback = character()) {
+status_package_refs <- function(status) {
   if (is.null(status) || !is.data.frame(status) || nrow(status) == 0L) {
-    return(fallback)
+    return(character())
   }
   packages <- status[["package"]]
   if (is.null(packages)) {
-    return(fallback)
+    return(character())
   }
   packages <- as.character(packages)
   refs <- packages
@@ -508,6 +562,11 @@ installed_package_refs <- function(status, fallback = character()) {
     bioc <- !is.na(repotypes) & tolower(as.character(repotypes)) == "bioc"
     refs[bioc & !use_remote] <- paste0("bioc::", packages[bioc & !use_remote])
   }
+  refs
+}
+
+installed_package_refs <- function(status, fallback = character()) {
+  refs <- status_package_refs(status)
   refs <- refs[!is.na(refs) & nzchar(refs)]
   if (length(refs) == 0L) fallback else refs
 }
@@ -566,16 +625,7 @@ merge_update_repos <- function(repos, status) {
         repository_identity(repos) == source_key
     )
     if (length(matches) == 0L) {
-      new_name <- "repository1"
-      while (new_name %in% repo_names) {
-        new_name <- paste0(
-          "repository",
-          as.integer(sub("^repository", "", new_name)) + 1L
-        )
-      }
-      repos <- c(source, repos)
-      repo_names <- c(new_name, repo_names)
-      matches <- 1L
+      next
     }
     order <- c(matches, setdiff(seq_along(repos), matches))
     repos <- repos[order]
@@ -585,11 +635,45 @@ merge_update_repos <- function(repos, status) {
   repos
 }
 
+status_repo_groups <- function(status, refs) {
+  valid <- !is.na(refs) & nzchar(refs)
+  indices <- which(valid)
+  if (length(indices) == 0L) {
+    return(list())
+  }
+  repositories <- status[["repository"]]
+  if (is.null(repositories)) {
+    return(list(indices))
+  }
+  repositories <- as.character(repositories)
+  remote_refs <- status[["remotepkgref"]]
+  use_remote <- if (is.null(remote_refs)) {
+    rep(FALSE, length(refs))
+  } else {
+    remote_refs <- as.character(remote_refs)
+    !is.na(remote_refs) & nzchar(remote_refs)
+  }
+  repotypes <- status[["repotype"]]
+  if (is.null(repotypes)) {
+    repotypes <- rep(NA_character_, length(refs))
+  }
+  repotypes <- tolower(as.character(repotypes))
+  standard <- !use_remote & (
+    repotypes %in% c("cran", "standard") | is.na(repotypes)
+  )
+  custom <- standard & !is.na(repositories) & nzchar(repositories) &
+    !tolower(repositories) %in% c("cran", "@cran@")
+  keys <- rep("", length(refs))
+  keys[custom] <- repository_identity(repositories[custom])
+  split(indices, keys[indices], drop = TRUE)
+}
+
 update_pkgs <- function(repos, r_lib = .libPaths()[1L],
                         depend = NA, quiet = FALSE,
                         pkg_install = NULL, installed_pkgs = NULL,
                         status_fn = NULL, installed_fn = installed.packages) {
   status <- NULL
+  status_refs <- NULL
   if (is.null(installed_pkgs)) {
     if (!is.function(installed_fn)) {
       stop("installed_fn must be a function.")
@@ -606,6 +690,7 @@ update_pkgs <- function(repos, r_lib = .libPaths()[1L],
         stop("status_fn must be a function.")
       }
       status <- status_fn(pkg = installed_names, lib = r_lib)
+      status_refs <- status_package_refs(status)
       installed_pkgs <- installed_package_refs(
         status,
         fallback = installed_names
@@ -618,6 +703,29 @@ update_pkgs <- function(repos, r_lib = .libPaths()[1L],
   if (length(installed_pkgs) == 0L) {
     message("No packages are installed in the clir library.")
     return(invisible(NULL))
+  }
+  if (!is.null(status) && !is.null(status_refs)) {
+    valid <- !is.na(status_refs) & nzchar(status_refs)
+    if (identical(status_refs[valid], installed_pkgs)) {
+      groups <- status_repo_groups(status, status_refs)
+      if (length(groups) > 0L) {
+        results <- lapply(groups, function(indices) {
+          install_pkgs(
+            pkgs = status_refs[indices],
+            repos = merge_update_repos(
+              repos,
+              status[indices, , drop = FALSE]
+            ),
+            r_lib = r_lib,
+            upgrade = TRUE,
+            depend = depend,
+            quiet = quiet,
+            pkg_install = pkg_install
+          )
+        })
+        return(invisible(results))
+      }
+    }
   }
   install_pkgs(
     pkgs = installed_pkgs,

--- a/src/util.R
+++ b/src/util.R
@@ -41,7 +41,9 @@ resolve_r_library <- function(clir_root_dir, r_version = getRversion(),
     names(env) <- c("R_LIBS_USER", "R_LIBS")[seq_along(env)]
   }
   overrides <- env[c("R_LIBS_USER", "R_LIBS")]
-  overrides <- overrides[!is.na(overrides) & nzchar(overrides)]
+  overrides <- overrides[
+    !is.na(overrides) & nzchar(overrides) & overrides != "NULL"
+  ]
   if (length(overrides) > 0L) {
     # R accepts a path list in these variables. The first entry is the
     # library used by clir, matching .libPaths()[[1]].

--- a/src/util.R
+++ b/src/util.R
@@ -414,11 +414,7 @@ standard_installed_refs <- function(status) {
     repotypes <- rep(NA_character_, length(packages))
   }
   repotypes <- tolower(as.character(repotypes))
-  repositories <- status[["repository"]]
-  if (is.null(repositories)) {
-    repositories <- rep(NA_character_, length(packages))
-  }
-  repositories <- as.character(repositories)
+  repositories <- status_repositories(status)
   standard <- !use_remote & (
     repotypes %in% c("cran", "standard", "bioc") |
       (!is.na(repositories) & nzchar(repositories))
@@ -552,6 +548,24 @@ install_pkgs <- function(pkgs, repos, r_lib = .libPaths()[1L],
   invisible(result)
 }
 
+status_repositories <- function(status) {
+  repositories <- status[["repository"]]
+  if (is.null(repositories)) {
+    repositories <- rep(NA_character_, nrow(status))
+  }
+  repositories <- as.character(repositories)
+  for (column in c("remoterepos", "RemoteRepos")) {
+    values <- status[[column]]
+    if (is.null(values)) {
+      next
+    }
+    values <- as.character(values)
+    missing <- is.na(repositories) | !nzchar(repositories)
+    repositories[missing] <- values[missing]
+  }
+  repositories
+}
+
 status_package_refs <- function(status) {
   if (is.null(status) || !is.data.frame(status) || nrow(status) == 0L) {
     return(character())
@@ -575,11 +589,7 @@ status_package_refs <- function(status) {
     repotypes <- rep(NA_character_, length(refs))
   }
   repotypes <- tolower(as.character(repotypes))
-  repositories <- status[["repository"]]
-  if (is.null(repositories)) {
-    repositories <- rep(NA_character_, length(refs))
-  }
-  repositories <- as.character(repositories)
+  repositories <- status_repositories(status)
   cran_repositories <- !is.na(repositories) &
     tolower(repositories) %in% c("cran", "@cran@")
   cran <- !use_remote &
@@ -613,11 +623,7 @@ merge_update_repos <- function(repos, status) {
   if (is.null(status) || !is.data.frame(status) || nrow(status) == 0L) {
     return(repos)
   }
-  repositories <- status[["repository"]]
-  if (is.null(repositories)) {
-    return(repos)
-  }
-  repositories <- as.character(repositories)
+  repositories <- status_repositories(status)
   packages <- status[["package"]]
   if (is.null(packages)) {
     return(repos)
@@ -686,11 +692,7 @@ status_repo_groups <- function(status, refs) {
   if (length(indices) == 0L) {
     return(list())
   }
-  repositories <- status[["repository"]]
-  if (is.null(repositories)) {
-    return(list(indices))
-  }
-  repositories <- as.character(repositories)
+  repositories <- status_repositories(status)
   remote_refs <- status[["remotepkgref"]]
   use_remote <- if (is.null(remote_refs)) {
     rep(FALSE, length(refs))

--- a/src/util.R
+++ b/src/util.R
@@ -123,7 +123,8 @@ make_clir_dirs <- function(clir_root_dir, r_lib = NULL,
     r_lib <- default_r_library(root, r_version = r_version)
   }
   paths <- unique(c(file.path(root, "r"), normalizePath(
-    path.expand(r_lib), mustWork = FALSE
+    path.expand(r_lib),
+    mustWork = FALSE
   )))
   for (path in paths) {
     dir.create(

--- a/src/util.R
+++ b/src/util.R
@@ -28,7 +28,7 @@ expand_r_library_tokens <- function(path, r_version = getRversion()) {
 
 resolve_r_library <- function(clir_root_dir, r_version = getRversion(),
                               r_lib = NULL,
-                              env = Sys.getenv(c("R_LIBS_USER", "R_LIBS"))) {
+                              env = Sys.getenv(c("R_LIBS", "R_LIBS_USER"))) {
   if (!is.null(r_lib)) {
     if (length(r_lib) != 1L || !nzchar(r_lib)) {
       stop("r_lib must be one non-empty path.")
@@ -38,9 +38,9 @@ resolve_r_library <- function(clir_root_dir, r_version = getRversion(),
 
   env <- as.character(env)
   if (is.null(names(env))) {
-    names(env) <- c("R_LIBS_USER", "R_LIBS")[seq_along(env)]
+    names(env) <- c("R_LIBS", "R_LIBS_USER")[seq_along(env)]
   }
-  overrides <- env[c("R_LIBS_USER", "R_LIBS")]
+  overrides <- env[c("R_LIBS", "R_LIBS_USER")]
   overrides <- overrides[
     !is.na(overrides) & nzchar(overrides) & overrides != "NULL"
   ]
@@ -168,13 +168,18 @@ normalize_repos <- function(config) {
   if (is.list(repos)) {
     repos <- unlist(repos, use.names = TRUE)
   }
+  repo_names <- names(repos)
   repos <- as.character(repos)
-  repos <- repos[!is.na(repos) & nzchar(repos)]
+  valid <- !is.na(repos) & nzchar(repos)
+  repos <- repos[valid]
+  if (!is.null(repo_names)) {
+    repo_names <- repo_names[valid]
+  }
   if (length(repos) == 0L) {
     repos <- default_config$repos
+    repo_names <- names(repos)
   }
 
-  repo_names <- names(repos)
   if (is.null(repo_names)) {
     repo_names <- rep("", length(repos))
   }
@@ -228,15 +233,19 @@ print_config <- function(clir_yml, r_lib = NULL, init = FALSE) {
 }
 
 add_config <- function(new, key, clir_yml) {
+  new_names <- names(new)
   new <- as.character(new)
-  new <- new[!is.na(new) & nzchar(new)]
+  valid <- !is.na(new) & nzchar(new)
+  new <- new[valid]
+  if (!is.null(new_names)) {
+    new_names <- new_names[valid]
+  }
   if (length(new) == 0L) {
     stop("At least one configuration value must be passed.")
   }
 
   config <- normalize_config(read_config(clir_yml))
   if (key %in% c("repos", "cran_urls")) {
-    new_names <- names(new)
     if (is.null(new_names)) {
       new_names <- rep("CRAN", length(new))
     } else {

--- a/src/util.R
+++ b/src/util.R
@@ -439,6 +439,9 @@ canonical_ref <- function(ref) {
   if (length(ref) != 1L || is.na(ref) || !nzchar(ref)) {
     return(ref)
   }
+  if (grepl("^[A-Za-z][A-Za-z0-9.]*=", ref)) {
+    return(canonical_ref(sub("^[A-Za-z][A-Za-z0-9.]*=", "", ref)))
+  }
   if (grepl("^github::", ref, ignore.case = TRUE)) {
     ref <- sub("^github::", "", ref, ignore.case = TRUE)
     ref <- sub("/+$", "", ref)
@@ -568,10 +571,32 @@ status_package_refs <- function(status) {
     use_remote <- rep(FALSE, length(refs))
   }
   repotypes <- status[["repotype"]]
-  if (!is.null(repotypes)) {
-    bioc <- !is.na(repotypes) & tolower(as.character(repotypes)) == "bioc"
-    refs[bioc & !use_remote] <- paste0("bioc::", packages[bioc & !use_remote])
+  if (is.null(repotypes)) {
+    repotypes <- rep(NA_character_, length(refs))
   }
+  repotypes <- tolower(as.character(repotypes))
+  repositories <- status[["repository"]]
+  if (is.null(repositories)) {
+    repositories <- rep(NA_character_, length(refs))
+  }
+  repositories <- as.character(repositories)
+  cran <- !use_remote &
+    (
+      repotypes %in% c("cran", "standard") |
+        (!is.na(repositories) &
+          tolower(repositories) %in% c("cran", "@cran@"))
+    ) &
+    (
+      is.na(repositories) |
+        !nzchar(repositories) |
+        tolower(repositories) %in% c("cran", "@cran@")
+    )
+  refs[cran] <- paste0("cran::", packages[cran])
+  bioc <- !is.na(repotypes) & repotypes == "bioc"
+  refs[bioc & !use_remote] <- paste0(
+    "bioc::",
+    packages[bioc & !use_remote]
+  )
   refs
 }
 

--- a/src/util.R
+++ b/src/util.R
@@ -147,7 +147,12 @@ reset_clir_library <- function(target, clir_root_dir,
     stop("Refusing to reset a non-directory clir library path.")
   }
 
-  status <- unlink_fn(target, recursive = TRUE, force = TRUE)
+  status <- unlink_fn(
+    target,
+    recursive = TRUE,
+    force = TRUE,
+    expand = FALSE
+  )
   if (!isTRUE(status == 0L)) {
     stop("Failed to reset the clir library.")
   }
@@ -276,9 +281,48 @@ print_cran_mirrors <- function(https = TRUE) {
   }
 }
 
+package_ref_name <- function(ref) {
+  ref <- as.character(ref)
+  ref <- sub("^[^:]+::", "", ref)
+  ref <- sub("@[^/@]+$", "", ref)
+  ref <- sub("[?#].*$", "", ref)
+  ref <- sub("/+$", "", ref)
+  ref <- basename(ref)
+  sub("\\.git$", "", ref)
+}
+
+filter_installed_pkgs <- function(pkgs, r_lib, installed_fn,
+                                  status_fn = NULL) {
+  if (!is.function(installed_fn)) {
+    stop("installed_fn must be a function.")
+  }
+  installed_names <- rownames(installed_fn(lib.loc = r_lib))
+  if (length(installed_names) == 0L) {
+    return(pkgs)
+  }
+
+  installed_refs <- installed_names
+  if (!is.null(status_fn)) {
+    if (!is.function(status_fn)) {
+      stop("status_fn must be a function.")
+    }
+    installed_refs <- c(
+      installed_refs,
+      installed_package_refs(
+        status_fn(pkg = installed_names, lib = r_lib),
+        fallback = installed_names
+      )
+    )
+  }
+  requested_names <- package_ref_name(pkgs)
+  keep <- !(requested_names %in% installed_names | pkgs %in% installed_refs)
+  pkgs[keep]
+}
+
 install_pkgs <- function(pkgs, repos, r_lib = .libPaths()[1L],
                          upgrade = TRUE, depend = NA, quiet = FALSE,
-                         pkg_install = NULL) {
+                         pkg_install = NULL, installed_fn = installed.packages,
+                         status_fn = NULL) {
   if (length(pkgs) == 0L) {
     stop("At least one package reference must be passed.")
   }
@@ -290,6 +334,22 @@ install_pkgs <- function(pkgs, repos, r_lib = .libPaths()[1L],
   }
   if (!is.function(pkg_install)) {
     stop("pkg_install must be a function.")
+  }
+
+  if (!upgrade) {
+    if (is.null(status_fn) && requireNamespace("pak", quietly = TRUE)) {
+      status_fn <- pak::pkg_status
+    }
+    pkgs <- filter_installed_pkgs(
+      pkgs = pkgs,
+      r_lib = r_lib,
+      installed_fn = installed_fn,
+      status_fn = status_fn
+    )
+    if (length(pkgs) == 0L) {
+      message("All requested packages are already installed.")
+      return(invisible(NULL))
+    }
   }
 
   options(repos = repos)

--- a/src/util.R
+++ b/src/util.R
@@ -580,16 +580,14 @@ status_package_refs <- function(status) {
     repositories <- rep(NA_character_, length(refs))
   }
   repositories <- as.character(repositories)
+  cran_repositories <- !is.na(repositories) &
+    tolower(repositories) %in% c("cran", "@cran@")
   cran <- !use_remote &
-    (
-      repotypes %in% c("cran", "standard") |
-        (!is.na(repositories) &
-          tolower(repositories) %in% c("cran", "@cran@"))
-    ) &
+    (repotypes %in% c("cran", "standard") | cran_repositories) &
     (
       is.na(repositories) |
         !nzchar(repositories) |
-        tolower(repositories) %in% c("cran", "@cran@")
+        cran_repositories
     )
   refs[cran] <- paste0("cran::", packages[cran])
   bioc <- !is.na(repotypes) & repotypes == "bioc"

--- a/src/util.R
+++ b/src/util.R
@@ -36,10 +36,12 @@ resolve_r_library <- function(clir_root_dir, r_version = getRversion(),
     return(normalizePath(path.expand(r_lib), mustWork = FALSE))
   }
 
+  env_names <- names(env)
   env <- as.character(env)
-  if (is.null(names(env))) {
-    names(env) <- c("R_LIBS", "R_LIBS_USER")[seq_along(env)]
+  if (is.null(env_names)) {
+    env_names <- c("R_LIBS", "R_LIBS_USER")[seq_along(env)]
   }
+  names(env) <- env_names
   overrides <- env[c("R_LIBS", "R_LIBS_USER")]
   overrides <- overrides[
     !is.na(overrides) & nzchar(overrides) & overrides != "NULL"

--- a/src/util.R
+++ b/src/util.R
@@ -441,7 +441,9 @@ canonical_ref <- function(ref) {
   if (grepl("^github::", ref, ignore.case = TRUE)) {
     ref <- sub("^github::", "", ref, ignore.case = TRUE)
     ref <- sub("/+$", "", ref)
-    return(paste0("github::", ref))
+    if (!grepl("^https?://github\\.com/", ref, ignore.case = TRUE)) {
+      return(paste0("github::", ref))
+    }
   }
   if (grepl("^https?://github\\.com/", ref, ignore.case = TRUE)) {
     ref <- sub("^https?://github\\.com/", "", ref, ignore.case = TRUE)

--- a/src/util.R
+++ b/src/util.R
@@ -394,6 +394,36 @@ is_plain_package_ref <- function(ref) {
   grepl("^[A-Za-z][A-Za-z0-9.]*$", ref)
 }
 
+status_uses_remote_ref <- function(status) {
+  if (is.null(status) || !is.data.frame(status)) {
+    return(logical())
+  }
+  remote_refs <- status[["remotepkgref"]]
+  if (is.null(remote_refs)) {
+    return(rep(FALSE, nrow(status)))
+  }
+  remote_refs <- as.character(remote_refs)
+  use_remote <- !is.na(remote_refs) & nzchar(remote_refs)
+  remote_types <- status[["remotetype"]]
+  if (is.null(remote_types)) {
+    remote_types <- status[["RemoteType"]]
+  }
+  explicit_type <- rep(FALSE, nrow(status))
+  if (!is.null(remote_types)) {
+    remote_types <- tolower(trimws(as.character(remote_types)))
+    explicit_type <- !is.na(remote_types) & nzchar(remote_types)
+    use_remote[explicit_type] <- use_remote[explicit_type] &
+      remote_types[explicit_type] != "standard"
+  }
+  repotypes <- status[["repotype"]]
+  if (!is.null(repotypes)) {
+    repotypes <- tolower(trimws(as.character(repotypes)))
+    standard_type <- repotypes %in% c("cran", "standard", "bioc")
+    use_remote[!explicit_type & standard_type] <- FALSE
+  }
+  use_remote
+}
+
 standard_installed_refs <- function(status) {
   if (is.null(status) || !is.data.frame(status) || nrow(status) == 0L) {
     return(character())
@@ -403,18 +433,17 @@ standard_installed_refs <- function(status) {
     return(character())
   }
   packages <- as.character(packages)
-  remote_refs <- status[["remotepkgref"]]
-  use_remote <- if (is.null(remote_refs)) {
-    rep(FALSE, length(packages))
-  } else {
-    remote_refs <- as.character(remote_refs)
-    !is.na(remote_refs) & nzchar(remote_refs)
-  }
+  use_remote <- status_uses_remote_ref(status)
   repotypes <- status[["repotype"]]
   if (is.null(repotypes)) {
     repotypes <- rep(NA_character_, length(packages))
   }
   repotypes <- tolower(as.character(repotypes))
+  original_repositories <- status[["repository"]]
+  if (is.null(original_repositories)) {
+    original_repositories <- rep(NA_character_, length(packages))
+  }
+  original_repositories <- as.character(original_repositories)
   repositories <- status_repositories(status)
   standard <- !use_remote & (
     repotypes %in% c("cran", "standard", "bioc") |
@@ -425,9 +454,9 @@ standard_installed_refs <- function(status) {
   }
   refs <- paste0("standard::", packages[standard])
   cran <- standard & repotypes %in% c("cran", "standard") & (
-    is.na(repositories) |
-      !nzchar(repositories) |
-      tolower(repositories) %in% c("cran", "@cran@")
+    is.na(original_repositories) |
+      !nzchar(original_repositories) |
+      tolower(original_repositories) %in% c("cran", "@cran@")
   )
   unique(c(refs, paste0("cran::", packages[cran])))
 }
@@ -586,12 +615,10 @@ status_package_refs <- function(status) {
   packages <- as.character(packages)
   refs <- packages
   remote_refs <- status[["remotepkgref"]]
+  use_remote <- status_uses_remote_ref(status)
   if (!is.null(remote_refs)) {
     remote_refs <- as.character(remote_refs)
-    use_remote <- !is.na(remote_refs) & nzchar(remote_refs)
     refs[use_remote] <- remote_refs[use_remote]
-  } else {
-    use_remote <- rep(FALSE, length(refs))
   }
   repotypes <- status[["repotype"]]
   if (is.null(repotypes)) {
@@ -637,13 +664,7 @@ merge_update_repos <- function(repos, status) {
   if (is.null(packages)) {
     return(repos)
   }
-  remote_refs <- status[["remotepkgref"]]
-  use_remote <- if (is.null(remote_refs)) {
-    rep(FALSE, length(repositories))
-  } else {
-    remote_refs <- as.character(remote_refs)
-    !is.na(remote_refs) & nzchar(remote_refs)
-  }
+  use_remote <- status_uses_remote_ref(status)
   repotypes <- status[["repotype"]]
   if (is.null(repotypes)) {
     repotypes <- rep(NA_character_, length(repositories))
@@ -702,13 +723,7 @@ status_repo_groups <- function(status, refs) {
     return(list())
   }
   repositories <- status_repositories(status)
-  remote_refs <- status[["remotepkgref"]]
-  use_remote <- if (is.null(remote_refs)) {
-    rep(FALSE, length(refs))
-  } else {
-    remote_refs <- as.character(remote_refs)
-    !is.na(remote_refs) & nzchar(remote_refs)
-  }
+  use_remote <- status_uses_remote_ref(status)
   repotypes <- status[["repotype"]]
   if (is.null(repotypes)) {
     repotypes <- rep(NA_character_, length(refs))

--- a/src/util.R
+++ b/src/util.R
@@ -193,7 +193,7 @@ normalize_repos <- function(config) {
 }
 
 normalize_config <- function(config) {
-  list(repos = normalize_repos(config))
+  list(repos = as.list(normalize_repos(config)))
 }
 
 read_config <- function(clir_yml) {
@@ -295,11 +295,59 @@ install_pkgs <- function(pkgs, repos, r_lib = .libPaths()[1L],
   invisible(result)
 }
 
+installed_package_refs <- function(status, fallback = character()) {
+  if (is.null(status) || !is.data.frame(status) || nrow(status) == 0L) {
+    return(fallback)
+  }
+  packages <- status[["package"]]
+  if (is.null(packages)) {
+    return(fallback)
+  }
+  packages <- as.character(packages)
+  refs <- packages
+  remote_refs <- status[["remotepkgref"]]
+  if (!is.null(remote_refs)) {
+    remote_refs <- as.character(remote_refs)
+    use_remote <- !is.na(remote_refs) & nzchar(remote_refs)
+    refs[use_remote] <- remote_refs[use_remote]
+  } else {
+    use_remote <- rep(FALSE, length(refs))
+  }
+  repotypes <- status[["repotype"]]
+  if (!is.null(repotypes)) {
+    bioc <- !is.na(repotypes) & tolower(as.character(repotypes)) == "bioc"
+    refs[bioc & !use_remote] <- paste0("bioc::", packages[bioc & !use_remote])
+  }
+  refs <- refs[!is.na(refs) & nzchar(refs)]
+  if (length(refs) == 0L) fallback else refs
+}
+
 update_pkgs <- function(repos, r_lib = .libPaths()[1L],
                         depend = NA, quiet = FALSE,
-                        pkg_install = NULL, installed_pkgs = NULL) {
+                        pkg_install = NULL, installed_pkgs = NULL,
+                        status_fn = NULL, installed_fn = installed.packages) {
   if (is.null(installed_pkgs)) {
-    installed_pkgs <- rownames(installed.packages(lib.loc = r_lib))
+    if (!is.function(installed_fn)) {
+      stop("installed_fn must be a function.")
+    }
+    installed_names <- rownames(installed_fn(lib.loc = r_lib))
+    if (length(installed_names) > 0L) {
+      if (is.null(status_fn)) {
+        if (!requireNamespace("pak", quietly = TRUE)) {
+          stop("The pak package is required for package status.")
+        }
+        status_fn <- pak::pkg_status
+      }
+      if (!is.function(status_fn)) {
+        stop("status_fn must be a function.")
+      }
+      installed_pkgs <- installed_package_refs(
+        status_fn(pkg = installed_names, lib = r_lib),
+        fallback = installed_names
+      )
+    } else {
+      installed_pkgs <- installed_names
+    }
   }
   if (length(installed_pkgs) == 0L) {
     message("No packages are installed in the clir library.")

--- a/src/util.R
+++ b/src/util.R
@@ -1,59 +1,250 @@
 #!/usr/bin/env Rscript
 
 default_config <- list(
-  cran_urls = c("https://cran.rstudio.com/"),
-  drat_repos = c("eddelbuettel")
+  repos = c(CRAN = "https://cran.rstudio.com/")
 )
 
-make_clir_dirs <- function(clir_root_dir, exist_ok = TRUE) {
-  sapply(file.path(clir_root_dir, c("r", "r/library")),
-    dir.create,
-    showWarnings = (!exist_ok)
+r_major_minor <- function(r_version = getRversion()) {
+  parts <- strsplit(as.character(r_version), ".", fixed = TRUE)[[1L]]
+  if (length(parts) < 2L) {
+    stop("An R version with a major and minor component is required.")
+  }
+  paste(parts[seq_len(2L)], collapse = ".")
+}
+
+default_r_library <- function(clir_root_dir, r_version = getRversion()) {
+  root <- normalizePath(path.expand(clir_root_dir), mustWork = FALSE)
+  file.path(root, "r", r_major_minor(r_version), "library")
+}
+
+expand_r_library_tokens <- function(path, r_version = getRversion()) {
+  version <- as.character(r_version)
+  gsub(
+    "%V", version,
+    gsub("%v", r_major_minor(r_version), path, fixed = TRUE),
+    fixed = TRUE
   )
 }
 
-load_repos <- function(clir_yml, quiet = FALSE) {
-  if (file.exists(clir_yml)) {
-    cf <- yaml::read_yaml(clir_yml)
-  } else {
-    cf <- default_config$cran_urls
+resolve_r_library <- function(clir_root_dir, r_version = getRversion(),
+                              r_lib = NULL,
+                              env = Sys.getenv(c("R_LIBS_USER", "R_LIBS"))) {
+  if (!is.null(r_lib)) {
+    if (length(r_lib) != 1L || !nzchar(r_lib)) {
+      stop("r_lib must be one non-empty path.")
+    }
+    return(normalizePath(path.expand(r_lib), mustWork = FALSE))
   }
-  if (require("drat", quietly = TRUE) && ("drat_repos" %in% names(cf))) {
-    drat:::addRepo(account = cf$drat_repos)
+
+  env <- as.character(env)
+  if (is.null(names(env))) {
+    names(env) <- c("R_LIBS_USER", "R_LIBS")[seq_along(env)]
   }
-  repos <- getOption("repos")
-  if ("cran_urls" %in% names(cf)) {
-    cran <- cf$cran_urls[1]
-  } else if (repos == "@CRAN@") {
-    cran <- default_config$cran_urls[1]
-  } else {
-    cran <- repos["CRAN"]
+  overrides <- env[c("R_LIBS_USER", "R_LIBS")]
+  overrides <- overrides[!is.na(overrides) & nzchar(overrides)]
+  if (length(overrides) > 0L) {
+    # R accepts a path list in these variables. The first entry is the
+    # library used by clir, matching .libPaths()[[1]].
+    path <- strsplit(overrides[[1L]], .Platform$path.sep, fixed = TRUE)[[1L]][1L]
+    path <- expand_r_library_tokens(path, r_version = r_version)
+    return(normalizePath(path.expand(path), mustWork = FALSE))
   }
-  c(CLAN = cran, repos[names(repos) != "CRAN"])
+
+  default_r_library(clir_root_dir = clir_root_dir, r_version = r_version)
 }
 
-print_config <- function(clir_yml, r_lib = .libPaths()[1], init = FALSE) {
-  if (init) {
-    cf <- default_config
-    yaml::write_yaml(cf, file = clir_yml)
-    message(stringr::str_c("Initialized: ", clir_yml))
-  } else if (file.exists(clir_yml)) {
-    cf <- yaml::read_yaml(clir_yml)
-  } else {
-    cf <- default_config
+make_clir_dirs <- function(clir_root_dir, r_lib = NULL,
+                           r_version = getRversion(), exist_ok = TRUE) {
+  root <- normalizePath(path.expand(clir_root_dir), mustWork = FALSE)
+  if (is.null(r_lib)) {
+    r_lib <- default_r_library(root, r_version = r_version)
   }
-  print(list(clir = cf, libpath = r_lib, r = version))
+  paths <- unique(c(file.path(root, "r"), normalizePath(
+    path.expand(r_lib), mustWork = FALSE
+  )))
+  for (path in paths) {
+    dir.create(
+      path,
+      recursive = TRUE,
+      showWarnings = !exist_ok
+    )
+  }
+  invisible(paths)
+}
+
+path_is_within <- function(path, root) {
+  path <- normalizePath(path, mustWork = FALSE)
+  root <- normalizePath(root, mustWork = FALSE)
+  identical(path, root) || startsWith(path, paste0(root, .Platform$file.sep))
+}
+
+is_symlink_path <- function(path) {
+  link <- Sys.readlink(path)
+  length(link) == 1L && !is.na(link) && nzchar(link)
+}
+
+path_components <- function(path) {
+  path <- path.expand(path)
+  if (!grepl("^/", path)) {
+    path <- file.path(getwd(), path)
+  }
+  parts <- strsplit(path, .Platform$file.sep, fixed = TRUE)[[1L]]
+  current <- if (startsWith(path, .Platform$file.sep)) {
+    .Platform$file.sep
+  } else {
+    ""
+  }
+  components <- character()
+  for (part in parts) {
+    if (!nzchar(part) || identical(part, ".")) {
+      next
+    }
+    current <- if (identical(current, .Platform$file.sep)) {
+      paste0(current, part)
+    } else if (nzchar(current)) {
+      file.path(current, part)
+    } else {
+      part
+    }
+    components <- c(components, current)
+  }
+  components
+}
+
+reset_clir_library <- function(target, clir_root_dir,
+                               r_version = getRversion()) {
+  root <- normalizePath(path.expand(clir_root_dir), mustWork = FALSE)
+  target_input <- path.expand(target)
+  expected_input <- default_r_library(root, r_version = r_version)
+  raw_components <- unique(c(
+    path_components(expected_input),
+    path_components(target_input)
+  ))
+  if (any(vapply(raw_components, is_symlink_path, logical(1)))) {
+    stop("Refusing to reset a symlinked clir library path.")
+  }
+
+  target <- normalizePath(target_input, mustWork = FALSE)
+  expected <- normalizePath(expected_input, mustWork = FALSE)
+  managed_root <- normalizePath(file.path(root, "r"), mustWork = FALSE)
+
+  if (!identical(target, expected)) {
+    stop("Refusing to reset a library outside the current clir library path.")
+  }
+  if (!path_is_within(target, managed_root) || identical(target, managed_root)) {
+    stop("Refusing to reset a path outside the clir-managed library root.")
+  }
+
+  if (file.exists(target) && !dir.exists(target)) {
+    stop("Refusing to reset a non-directory clir library path.")
+  }
+
+  unlink(target, recursive = TRUE, force = TRUE)
+  invisible(TRUE)
+}
+
+normalize_repos <- function(config) {
+  if (is.null(config) || !is.list(config)) {
+    config <- list()
+  }
+  repos <- config[["repos"]]
+  if (is.null(repos)) {
+    # Read the pre-pak configuration format so an upgrade does not silently
+    # discard a user's CRAN mirror.
+    repos <- config[["cran_urls"]]
+  }
+  if (is.null(repos)) {
+    repos <- default_config$repos
+  }
+  if (is.list(repos)) {
+    repos <- unlist(repos, use.names = TRUE)
+  }
+  repos <- as.character(repos)
+  repos <- repos[!is.na(repos) & nzchar(repos)]
+  if (length(repos) == 0L) {
+    repos <- default_config$repos
+  }
+
+  repo_names <- names(repos)
+  if (is.null(repo_names)) {
+    repo_names <- rep("", length(repos))
+  }
+  missing_names <- is.na(repo_names) | !nzchar(repo_names)
+  if (any(missing_names)) {
+    replacements <- c("CRAN", paste0("repository", seq_len(max(0L, length(repos) - 1L))))
+    repo_names[missing_names] <- replacements[seq_len(sum(missing_names))]
+  }
+  repo_names[tolower(repo_names) == "cran"] <- "CRAN"
+  if (!any(repo_names == "CRAN")) {
+    repos <- c(default_config$repos, repos)
+    repo_names <- names(repos)
+  }
+  names(repos) <- repo_names
+  repos[!duplicated(names(repos))]
+}
+
+normalize_config <- function(config) {
+  list(repos = normalize_repos(config))
+}
+
+read_config <- function(clir_yml) {
+  if (file.exists(clir_yml)) {
+    yaml::read_yaml(clir_yml)
+  } else {
+    default_config
+  }
+}
+
+write_config <- function(config, clir_yml) {
+  dir.create(dirname(clir_yml), recursive = TRUE, showWarnings = FALSE)
+  yaml::write_yaml(normalize_config(config), file = clir_yml)
+}
+
+load_repos <- function(clir_yml, quiet = FALSE) {
+  normalize_repos(read_config(clir_yml))
+}
+
+print_config <- function(clir_yml, r_lib = NULL, init = FALSE) {
+  if (init) {
+    config <- normalize_config(default_config)
+    write_config(config, clir_yml)
+    message(paste("Initialized:", clir_yml))
+  } else {
+    config <- normalize_config(read_config(clir_yml))
+  }
+  if (is.null(r_lib)) {
+    r_lib <- .libPaths()[1L]
+  }
+  print(list(clir = config, libpath = r_lib, r = version))
 }
 
 add_config <- function(new, key, clir_yml) {
-  if (file.exists(clir_yml)) {
-    cf <- yaml::read_yaml(clir_yml)
-    cf[[key]] <- c(new, setdiff(cf[[key]], new))
-  } else {
-    cf <- default_config
+  new <- as.character(new)
+  new <- new[!is.na(new) & nzchar(new)]
+  if (length(new) == 0L) {
+    stop("At least one configuration value must be passed.")
   }
-  yaml::write_yaml(cf, file = clir_yml)
-  message(stringr::str_c("Updated: ", clir_yml))
+
+  config <- normalize_config(read_config(clir_yml))
+  if (key %in% c("repos", "cran_urls")) {
+    new_names <- names(new)
+    if (is.null(new_names)) {
+      new_names <- rep("CRAN", length(new))
+    } else {
+      new_names[is.na(new_names) | !nzchar(new_names)] <- "CRAN"
+      new_names[tolower(new_names) == "cran"] <- "CRAN"
+    }
+    names(new) <- new_names
+    new <- new[!duplicated(names(new))]
+    repos <- c(new, config$repos)
+    config <- list(repos = repos[!duplicated(names(repos))])
+  } else {
+    old <- read_config(clir_yml)[[key]]
+    config[[key]] <- unique(c(new, as.character(old)))
+  }
+  write_config(config, clir_yml)
+  message(paste("Updated:", clir_yml))
+  invisible(config)
 }
 
 print_cran_mirrors <- function(https = TRUE) {
@@ -65,132 +256,99 @@ print_cran_mirrors <- function(https = TRUE) {
   }
 }
 
-load_n_run_bioclite <- function(pkgs, repos, r_lib = .libPaths()[1], ...) {
-  BiocManager::install(
-    pkgs = pkgs, lib.loc = r_lib, lib = r_lib,
-    siteRepos = repos, update = TRUE, ask = FALSE, ...
-  )
-}
-
-update_pkgs <- function(repos, bioc = FALSE, r_lib = .libPaths()[1],
-                        check_built = TRUE, quiet = FALSE) {
-  if (bioc) {
-    load_n_run_bioclite(
-      pkgs = rownames(installed.packages(lib.loc = r_lib)),
-      repos = repos, r_lib = r_lib, checkBuilt = check_built,
-      quiet = quiet
-    )
-  } else {
-    update.packages(
-      lib.loc = r_lib, repos = repos, ask = FALSE,
-      checkBuilt = check_built, quiet = quiet
-    )
+install_pkgs <- function(pkgs, repos, r_lib = .libPaths()[1L],
+                         upgrade = TRUE, depend = NA, quiet = FALSE,
+                         pkg_install = NULL) {
+  if (length(pkgs) == 0L) {
+    stop("At least one package reference must be passed.")
   }
-}
-
-install_pkgs <- function(pkgs, repos, devt, bioc = FALSE,
-                         r_lib = .libPaths()[1], check_built = TRUE,
-                         upgrade = TRUE, depend = TRUE, quiet = FALSE,
-                         clean = TRUE) {
-  installed_pkgs <- rownames(installed.packages(lib.loc = r_lib))
-  ps <- list(
-    all = pkgs,
-    old = intersect(pkgs, installed_pkgs),
-    new = setdiff(pkgs, installed_pkgs)
-  )
-  if (upgrade || (length(ps$new) > 0)) {
-    if (is.null(devt)) {
-      if (bioc) {
-        load_n_run_bioclite(
-          pkgs = ps$all, repos = repos, r_lib = r_lib,
-          checkBuilt = check_built, quiet = quiet
-        )
-      } else {
-        if (upgrade && (length(ps$old) > 0)) {
-          update.packages(
-            instPkgs = ps$old, repos = repos, lib.loc = r_lib,
-            ask = FALSE, checkBuilt = check_built, quiet = quiet
-          )
-        }
-        if (length(ps$new) > 0) {
-          install.packages(
-            pkgs = ps$new, repos = repos, lib = r_lib,
-            dependencies = depend, quiet = quiet, clean = clean
-          )
-        }
-      }
-    } else if (devt %in% c("cran", "github", "bitbucket", "bioc")) {
-      if (!require("devtools", quietly = TRUE)) {
-        install.packages(
-          pkgs = "devtools", repos = repos, lib = r_lib,
-          dependencies = TRUE, quiet = quiet, clean = clean
-        )
-      }
-      if (require("devtools", quietly = TRUE)) {
-        if (upgrade) {
-          targets <- ps$all
-        } else {
-          targets <- ps$new
-        }
-        f <- switch(devt,
-          "cran" = devtools::install_cran,
-          "github" = devtools::install_github,
-          "bitbucket" = devtools::install_bitbucket,
-          "bioc" = devtools::install_bioc
-        )
-        withr::with_libpaths(
-          r_lib,
-          f(targets, dependencies = depend, quiet = quiet)
-        )
-      } else {
-        stop("Loading of devtools failed.")
-      }
-    } else {
-      stop("Invalid installation type.")
+  if (is.null(pkg_install)) {
+    if (!requireNamespace("pak", quietly = TRUE)) {
+      stop("The pak package is required for installation.")
     }
-  } else {
-    message("The packages already installed.")
+    pkg_install <- pak::pkg_install
   }
+  if (!is.function(pkg_install)) {
+    stop("pkg_install must be a function.")
+  }
+
+  options(repos = repos)
+  install <- function() {
+    pkg_install(
+      pkg = pkgs,
+      lib = r_lib,
+      upgrade = upgrade,
+      ask = FALSE,
+      dependencies = depend
+    )
+  }
+  result <- if (quiet) suppressMessages(install()) else install()
+  invisible(result)
+}
+
+update_pkgs <- function(repos, r_lib = .libPaths()[1L],
+                        depend = NA, quiet = FALSE,
+                        pkg_install = NULL, installed_pkgs = NULL) {
+  if (is.null(installed_pkgs)) {
+    installed_pkgs <- rownames(installed.packages(lib.loc = r_lib))
+  }
+  if (length(installed_pkgs) == 0L) {
+    message("No packages are installed in the clir library.")
+    return(invisible(NULL))
+  }
+  install_pkgs(
+    pkgs = installed_pkgs,
+    repos = repos,
+    r_lib = r_lib,
+    upgrade = TRUE,
+    depend = depend,
+    quiet = quiet,
+    pkg_install = pkg_install
+  )
 }
 
 validate_loading <- function(pkgs, quiet = FALSE) {
-  v <- sapply(as.vector(pkgs), require, character.only = TRUE)
-  result <- list(succeeded = names(v)[v], failed = names(v)[!v])
+  result <- vapply(
+    as.character(pkgs),
+    require,
+    logical(1),
+    character.only = TRUE,
+    quietly = quiet
+  )
+  names(result) <- as.character(pkgs)
+  result <- list(succeeded = names(result)[result], failed = names(result)[!result])
   if (!quiet) {
-    if (require("devtools", quietly = TRUE)) {
-      print(devtools::session_info(pkgs = pkgs, include_base = TRUE))
+    cat("\n- Loading test ", paste(rep("-", 63L), collapse = ""), "\n", sep = "")
+    if (length(result$succeeded) > 0L) {
+      cat(" Succeeded:\n  - ", paste(result$succeeded, collapse = "\n  - "), "\n", sep = "")
     }
-    cat("\n- Loading test ", stringr::str_c(rep("-", 63), collapse = ""), "\n",
-      sep = ""
-    )
-    if (length(result$succeeded) > 0) {
-      cat(" Succeeded:\n  - ",
-        stringr::str_c(result$succeeded, collapse = "\n  - "), "\n",
-        sep = ""
-      )
-    }
-    if (length(result$failed) > 0) {
-      cat(" Failed:\n  - ",
-        stringr::str_c(result$failed, collapse = "\n  - "), "\n",
-        sep = ""
-      )
+    if (length(result$failed) > 0L) {
+      cat(" Failed:\n  - ", paste(result$failed, collapse = "\n  - "), "\n", sep = "")
     }
     cat("\n")
-    if (length(result$failed) == 0) {
+    if (length(result$failed) == 0L) {
       message("Loading succeeded.")
     }
   }
-  if (length(result$failed) > 0) {
+  if (length(result$failed) > 0L) {
     stop("Loading failed.")
   }
+  invisible(result)
 }
 
 print_sessions <- function(pkgs) {
-  if (!require("devtools", quietly = TRUE)) {
-    stop("This command requires devtools.")
-  } else if (length(pkgs) > 0) {
-    devtools::session_info(pkgs = pkgs, include_base = TRUE)
-  } else {
-    devtools::session_info(include_base = TRUE)
+  pkgs <- as.character(pkgs)
+  if (length(pkgs) > 0L) {
+    loaded <- vapply(
+      pkgs,
+      require,
+      logical(1),
+      character.only = TRUE,
+      quietly = FALSE
+    )
+    if (any(!loaded)) {
+      stop("Loading failed.")
+    }
   }
+  print(utils::sessionInfo())
 }

--- a/src/util.R
+++ b/src/util.R
@@ -218,6 +218,16 @@ reset_clir_library <- function(target, clir_root_dir,
   invisible(TRUE)
 }
 
+repo_fallback_names <- function(n) {
+  if (n == 0L) {
+    return(character())
+  }
+  c(
+    "CRAN",
+    if (n > 1L) paste0("repository", seq_len(n - 1L)) else character()
+  )
+}
+
 normalize_repos <- function(config) {
   if (is.null(config) || !is.list(config)) {
     config <- list()
@@ -246,12 +256,12 @@ normalize_repos <- function(config) {
     repo_names <- names(repos)
   }
 
-  if (is.null(repo_names)) {
+  if (is.null(repo_names) || length(repo_names) != length(repos)) {
     repo_names <- rep("", length(repos))
   }
   missing_names <- is.na(repo_names) | !nzchar(repo_names)
   if (any(missing_names)) {
-    replacements <- c("CRAN", paste0("repository", seq_len(max(0L, length(repos) - 1L))))
+    replacements <- repo_fallback_names(length(repos))
     repo_names[missing_names] <- replacements[seq_len(sum(missing_names))]
   }
   repo_names[tolower(repo_names) == "cran"] <- "CRAN"
@@ -312,18 +322,12 @@ add_config <- function(new, key, clir_yml) {
 
   config <- normalize_config(read_config(clir_yml))
   if (key %in% c("repos", "cran_urls")) {
-    if (is.null(new_names)) {
-      new_names <- c(
-        "CRAN",
-        paste0("repository", seq_len(max(0L, length(new) - 1L)))
-      )
+    if (is.null(new_names) || length(new_names) != length(new)) {
+      new_names <- repo_fallback_names(length(new))
     } else {
       missing_names <- is.na(new_names) | !nzchar(new_names)
       if (any(missing_names)) {
-        replacements <- c(
-          "CRAN",
-          paste0("repository", seq_len(max(0L, length(new) - 1L)))
-        )
+        replacements <- repo_fallback_names(length(new))
         new_names[missing_names] <- replacements[seq_len(sum(missing_names))]
       }
       new_names[tolower(new_names) == "cran"] <- "CRAN"
@@ -364,6 +368,45 @@ is_plain_package_ref <- function(ref) {
   grepl("^[A-Za-z][A-Za-z0-9.]*$", ref)
 }
 
+installed_standard_package_refs <- function(status) {
+  if (is.null(status) || !is.data.frame(status) || nrow(status) == 0L) {
+    return(character())
+  }
+  packages <- status[["package"]]
+  if (is.null(packages)) {
+    return(character())
+  }
+  packages <- as.character(packages)
+  remote_refs <- status[["remotepkgref"]]
+  use_remote <- if (is.null(remote_refs)) {
+    rep(FALSE, length(packages))
+  } else {
+    remote_refs <- as.character(remote_refs)
+    !is.na(remote_refs) & nzchar(remote_refs)
+  }
+  repotypes <- status[["repotype"]]
+  if (is.null(repotypes)) {
+    repotypes <- rep(NA_character_, length(packages))
+  }
+  repotypes <- tolower(as.character(repotypes))
+  repositories <- status[["repository"]]
+  if (is.null(repositories)) {
+    repositories <- rep(NA_character_, length(packages))
+  }
+  repositories <- as.character(repositories)
+  standard <- !use_remote & repotypes %in% c("cran", "standard")
+  if (!any(standard)) {
+    return(character())
+  }
+  refs <- paste0("standard::", packages[standard])
+  cran <- standard & (
+    is.na(repositories) |
+      !nzchar(repositories) |
+      tolower(repositories) %in% c("cran", "@cran@")
+  )
+  unique(c(refs, paste0("cran::", packages[cran])))
+}
+
 filter_installed_pkgs <- function(pkgs, r_lib, installed_fn,
                                   status_fn = NULL) {
   if (!is.function(installed_fn)) {
@@ -379,12 +422,11 @@ filter_installed_pkgs <- function(pkgs, r_lib, installed_fn,
     if (!is.function(status_fn)) {
       stop("status_fn must be a function.")
     }
+    status <- status_fn(pkg = installed_names, lib = r_lib)
     installed_refs <- c(
       installed_refs,
-      installed_package_refs(
-        status_fn(pkg = installed_names, lib = r_lib),
-        fallback = installed_names
-      )
+      installed_standard_package_refs(status),
+      installed_package_refs(status, fallback = installed_names)
     )
   }
   requested_names <- package_ref_name(pkgs)
@@ -470,10 +512,84 @@ installed_package_refs <- function(status, fallback = character()) {
   if (length(refs) == 0L) fallback else refs
 }
 
+repository_identity <- function(value) {
+  value <- tolower(trimws(as.character(value)))
+  sub("/+$", "", value)
+}
+
+merge_update_repos <- function(repos, status) {
+  if (is.null(status) || !is.data.frame(status) || nrow(status) == 0L) {
+    return(repos)
+  }
+  repositories <- status[["repository"]]
+  if (is.null(repositories)) {
+    return(repos)
+  }
+  repositories <- as.character(repositories)
+  packages <- status[["package"]]
+  if (is.null(packages)) {
+    return(repos)
+  }
+  remote_refs <- status[["remotepkgref"]]
+  use_remote <- if (is.null(remote_refs)) {
+    rep(FALSE, length(repositories))
+  } else {
+    remote_refs <- as.character(remote_refs)
+    !is.na(remote_refs) & nzchar(remote_refs)
+  }
+  repotypes <- status[["repotype"]]
+  if (is.null(repotypes)) {
+    repotypes <- rep(NA_character_, length(repositories))
+  }
+  repotypes <- tolower(as.character(repotypes))
+  standard <- !use_remote & (
+    repotypes %in% c("cran", "standard") | is.na(repotypes)
+  )
+  sources <- repositories[
+    standard & !is.na(repositories) & nzchar(repositories) &
+      !tolower(repositories) %in% c("cran", "@cran@")
+  ]
+  sources <- unique(sources)
+  if (length(sources) == 0L) {
+    return(repos)
+  }
+
+  repos <- as.character(repos)
+  repo_names <- names(repos)
+  if (is.null(repo_names) || length(repo_names) != length(repos)) {
+    repo_names <- repo_fallback_names(length(repos))
+  }
+  for (source in sources) {
+    source_key <- repository_identity(source)
+    matches <- which(
+      repository_identity(repo_names) == source_key |
+        repository_identity(repos) == source_key
+    )
+    if (length(matches) == 0L) {
+      new_name <- "repository1"
+      while (new_name %in% repo_names) {
+        new_name <- paste0(
+          "repository",
+          as.integer(sub("^repository", "", new_name)) + 1L
+        )
+      }
+      repos <- c(source, repos)
+      repo_names <- c(new_name, repo_names)
+      matches <- 1L
+    }
+    order <- c(matches, setdiff(seq_along(repos), matches))
+    repos <- repos[order]
+    repo_names <- repo_names[order]
+  }
+  names(repos) <- repo_names
+  repos
+}
+
 update_pkgs <- function(repos, r_lib = .libPaths()[1L],
                         depend = NA, quiet = FALSE,
                         pkg_install = NULL, installed_pkgs = NULL,
                         status_fn = NULL, installed_fn = installed.packages) {
+  status <- NULL
   if (is.null(installed_pkgs)) {
     if (!is.function(installed_fn)) {
       stop("installed_fn must be a function.")
@@ -489,10 +605,12 @@ update_pkgs <- function(repos, r_lib = .libPaths()[1L],
       if (!is.function(status_fn)) {
         stop("status_fn must be a function.")
       }
+      status <- status_fn(pkg = installed_names, lib = r_lib)
       installed_pkgs <- installed_package_refs(
-        status_fn(pkg = installed_names, lib = r_lib),
+        status,
         fallback = installed_names
       )
+      repos <- merge_update_repos(repos, status)
     } else {
       installed_pkgs <- installed_names
     }

--- a/src/util.R
+++ b/src/util.R
@@ -112,7 +112,11 @@ path_components <- function(path) {
 }
 
 reset_clir_library <- function(target, clir_root_dir,
-                               r_version = getRversion()) {
+                               r_version = getRversion(),
+                               unlink_fn = unlink) {
+  if (!is.function(unlink_fn)) {
+    stop("unlink_fn must be a function.")
+  }
   root <- normalizePath(path.expand(clir_root_dir), mustWork = FALSE)
   target_input <- path.expand(target)
   expected_input <- default_r_library(root, r_version = r_version)
@@ -139,7 +143,10 @@ reset_clir_library <- function(target, clir_root_dir,
     stop("Refusing to reset a non-directory clir library path.")
   }
 
-  unlink(target, recursive = TRUE, force = TRUE)
+  status <- unlink_fn(target, recursive = TRUE, force = TRUE)
+  if (!isTRUE(status == 0L)) {
+    stop("Failed to reset the clir library.")
+  }
   invisible(TRUE)
 }
 

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -167,64 +167,36 @@ env -u R_LIBS_USER \
 [[ "$(grep -c '^R$' "${launcher_probe_count}")" = 0 ]]
 [[ "$(grep -c '^Rscript$' "${launcher_probe_count}")" = 1 ]]
 
-# shellcheck disable=SC2016
-printf 'R_LIBS_USER=${R_LIBS_USER-default}\n' >"${test_root}/.Renviron"
 conditional_system_user="${test_root}/system-user-default"
-: >"${launcher_probe_count}"
-env -u R_LIBS_USER -u R_LIBS \
-  HOME="${test_root}" \
-  CLIR_TEST_RECORD="${launcher_record}" \
-  CLIR_TEST_PROBE_COUNT="${launcher_probe_count}" \
-  CLIR_TEST_VANILLA_USER="${conditional_system_user}" \
-  PATH="${fake_bin}:${PATH}" \
-  "${cli}" --version
-grep -Fxq "${conditional_system_user}" "${launcher_record}"
-[[ "$(grep -c '^R$' "${launcher_probe_count}")" = 2 ]]
-[[ "$(grep -c '^Rscript$' "${launcher_probe_count}")" = 1 ]]
-
-# shellcheck disable=SC2016
-printf 'R_LIBS_USER=${R_LIBS_USER:-default}\n' >"${test_root}/.Renviron"
-: >"${launcher_probe_count}"
-env -u R_LIBS_USER -u R_LIBS \
-  HOME="${test_root}" \
-  CLIR_TEST_RECORD="${launcher_record}" \
-  CLIR_TEST_PROBE_COUNT="${launcher_probe_count}" \
-  CLIR_TEST_VANILLA_USER="${conditional_system_user}" \
-  PATH="${fake_bin}:${PATH}" \
-  "${cli}" --version
-grep -Fxq "${conditional_system_user}" "${launcher_record}"
-[[ "$(grep -c '^R$' "${launcher_probe_count}")" = 2 ]]
-[[ "$(grep -c '^Rscript$' "${launcher_probe_count}")" = 1 ]]
-
-# shellcheck disable=SC2016
-printf 'R_LIBS=${R_LIBS-default}\n' >"${test_root}/.Renviron"
-: >"${launcher_probe_count}"
-env -u R_LIBS_USER -u R_LIBS \
-  HOME="${test_root}" \
-  CLIR_TEST_RECORD="${launcher_record}" \
-  CLIR_TEST_PROBE_COUNT="${launcher_probe_count}" \
-  CLIR_TEST_VANILLA_USER="${conditional_system_user}" \
-  PATH="${fake_bin}:${PATH}" \
-  "${cli}" --version
-[[ "$(sed -n '1p' "${launcher_record}")" != 'NULL' ]]
-[[ "$(sed -n '2p' "${launcher_record}")" = 'conditional-r-default' ]]
-[[ "$(grep -c '^R$' "${launcher_probe_count}")" = 2 ]]
-[[ "$(grep -c '^Rscript$' "${launcher_probe_count}")" = 1 ]]
-
-# shellcheck disable=SC2016
-printf 'R_LIBS=${R_LIBS:-default}\n' >"${test_root}/.Renviron"
-: >"${launcher_probe_count}"
-env -u R_LIBS_USER -u R_LIBS \
-  HOME="${test_root}" \
-  CLIR_TEST_RECORD="${launcher_record}" \
-  CLIR_TEST_PROBE_COUNT="${launcher_probe_count}" \
-  CLIR_TEST_VANILLA_USER="${conditional_system_user}" \
-  PATH="${fake_bin}:${PATH}" \
-  "${cli}" --version
-[[ "$(sed -n '1p' "${launcher_record}")" != 'NULL' ]]
-[[ "$(sed -n '2p' "${launcher_record}")" = 'conditional-r-default' ]]
-[[ "$(grep -c '^R$' "${launcher_probe_count}")" = 2 ]]
-[[ "$(grep -c '^Rscript$' "${launcher_probe_count}")" = 1 ]]
+conditional_cases=(
+  "user-dash|R_LIBS_USER|\${R_LIBS_USER-default}|${conditional_system_user}|UNSET"
+  "user-colon-dash|R_LIBS_USER|\${R_LIBS_USER:-default}|${conditional_system_user}|UNSET"
+  "r-dash|R_LIBS|\${R_LIBS-default}|UNSET|conditional-r-default"
+  "r-colon-dash|R_LIBS|\${R_LIBS:-default}|UNSET|conditional-r-default"
+)
+for conditional_case in "${conditional_cases[@]}"; do
+  IFS='|' read -r case_id variable expression expected_user expected_r <<<"${conditional_case}"
+  # shellcheck disable=SC2016
+  printf '%s=%s\n' "${variable}" "${expression}" >"${test_root}/.Renviron"
+  : >"${launcher_probe_count}"
+  env -u R_LIBS_USER -u R_LIBS \
+    HOME="${test_root}" \
+    CLIR_TEST_RECORD="${launcher_record}" \
+    CLIR_TEST_PROBE_COUNT="${launcher_probe_count}" \
+    CLIR_TEST_VANILLA_USER="${conditional_system_user}" \
+    PATH="${fake_bin}:${PATH}" \
+    "${cli}" --version
+  [[ "$(sed -n '1p' "${launcher_record}")" = "${expected_user}" ]] || {
+    echo "conditional startup case failed: ${case_id}" >&2
+    exit 1
+  }
+  [[ "$(sed -n '2p' "${launcher_record}")" = "${expected_r}" ]] || {
+    echo "conditional startup case failed: ${case_id}" >&2
+    exit 1
+  }
+  [[ "$(grep -c '^R$' "${launcher_probe_count}")" = 2 ]]
+  [[ "$(grep -c '^Rscript$' "${launcher_probe_count}")" = 1 ]]
+done
 
 same_default_user=$(env -u R_LIBS_USER -u R_LIBS -u R_ENVIRON_USER -u R_PROFILE_USER \
   HOME="${test_root}" \

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -193,7 +193,7 @@ run_cli() {
   env "${cli_env[@]}" "${cli}" "${@}"
 }
 
-run_cli --version | grep -Fq 'v1.2.1'
+run_cli --version | grep -Fq 'v2.0.0'
 help_output=$(run_cli --help)
 grep -Fq 'pak' <<<"${help_output}"
 if grep -Eq 'drat|--devt|--bioc' <<<"${help_output}"; then

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -153,6 +153,7 @@ cat >"${installer_fake_bin}/Rscript" <<'EOF'
 set -euo pipefail
 args=" $* "
 [[ "${args}" != *' -d '* ]]
+[[ "${CLIR_R_LIBS_USER:-}" = "${CLIR_TEST_ENV_LIBRARY}" ]]
 if [[ "${args}" != *'--no-init-file'* &&
   "${args}" != *'--vanilla'* &&
   -f "${HOME}/.Rprofile" ]] &&

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -33,6 +33,13 @@ env -u R_LIBS_USER -u R_LIBS \
   "${cli}" --version
 grep -Fxq "${test_root}/r/4.3/library" "${launcher_record}"
 
+env -u R_LIBS \
+  R_LIBS_USER='NULL' \
+  CLIR_TEST_RECORD="${launcher_record}" \
+  PATH="${fake_bin}:${PATH}" \
+  "${cli}" --version
+grep -Fxq "${test_root}/r/4.3/library" "${launcher_record}"
+
 explicit_user="${test_root}/explicit-user"
 env -u R_LIBS \
   R_LIBS_USER="${explicit_user}" \

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -111,22 +111,21 @@ grep -Fq 'repos' "${test_root}/r/clir.yml"
 run_cli cran https://example.invalid/cran >/dev/null
 grep -Fq 'https://example.invalid/cran' "${test_root}/r/clir.yml"
 
-if run_cli drat example >/dev/null 2>&1; then
-  echo 'removed drat command was accepted' >&2
-  exit 1
-fi
-if run_cli install --devt=cran example >/dev/null 2>&1; then
-  echo 'removed --devt option was accepted' >&2
-  exit 1
-fi
-if run_cli install --bioc example >/dev/null 2>&1; then
-  echo 'removed --bioc option was accepted' >&2
-  exit 1
-fi
+assert_parser_rejects() {
+  local expected output
+  expected=${1}
+  shift
+  if output=$(run_cli "$@" 2>&1); then
+    echo "parser accepted removed interface: $*" >&2
+    exit 1
+  fi
+  grep -Fq 'Usage:' <<<"${output}"
+  grep -Fq -- "${expected}" <<<"${output}"
+}
 
-if run_cli --invalid-option >/dev/null 2>&1; then
-  echo 'invalid option was accepted' >&2
-  exit 1
-fi
+assert_parser_rejects 'drat' drat example
+assert_parser_rejects '--devt' install --devt=cran example
+assert_parser_rejects '--bioc' install --bioc example
+assert_parser_rejects '--invalid-option' --invalid-option
 
 echo 'All CLI tests passed.'

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -119,8 +119,8 @@ if [[ "${args}" != *'--no-environ'* &&
 fi
 if [[ "${args}" != *'--no-init-file'* &&
   "${args}" != *'--vanilla'* &&
-  -f "${HOME}/.Rprofile" &&
-  grep -Fq 'CLIR_TEST_PROFILE=enabled' "${HOME}/.Rprofile" ]]; then
+  -f "${HOME}/.Rprofile" ]] &&
+  grep -Fq 'CLIR_TEST_PROFILE=enabled' "${HOME}/.Rprofile"; then
   printf 'profile-noise'
   touch "${CLIR_TEST_PROBE_MARKER}"
 fi
@@ -154,8 +154,8 @@ set -euo pipefail
 args=" $* "
 if [[ "${args}" != *'--no-init-file'* &&
   "${args}" != *'--vanilla'* &&
-  -f "${HOME}/.Rprofile" &&
-  grep -Fq 'CLIR_TEST_PROFILE=enabled' "${HOME}/.Rprofile" ]]; then
+  -f "${HOME}/.Rprofile" ]] &&
+  grep -Fq 'CLIR_TEST_PROFILE=enabled' "${HOME}/.Rprofile"; then
   touch "${CLIR_TEST_PROFILE_MARKER}"
 fi
 [[ "${R_LIBS_USER:-}" = "${CLIR_TEST_ENV_LIBRARY}" ]]

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -152,6 +152,7 @@ cat >"${installer_fake_bin}/Rscript" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 args=" $* "
+[[ "${args}" != *' -d '* ]]
 if [[ "${args}" != *'--no-init-file'* &&
   "${args}" != *'--vanilla'* &&
   -f "${HOME}/.Rprofile" ]] &&
@@ -173,7 +174,7 @@ CLIR_TEST_PROBE_MARKER="${test_root}/probe-profile-marker" \
 CLIR_TEST_PROFILE_MARKER="${test_root}/runtime-profile-marker" \
 HOME="${test_root}" \
 PATH="${installer_fake_bin}:${PATH}" \
-  "${installer_root}/install_clir.sh"
+  "${installer_root}/install_clir.sh" --debug
 [[ -f "${installer_marker}" ]]
 [[ ! -e "${test_root}/managed-marker" ]]
 [[ ! -e "${test_root}/probe-profile-marker" ]]

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -17,21 +17,45 @@ fake_bin="${test_root}/fake-bin"
 mkdir -p "${fake_bin}"
 cat >"${fake_bin}/R" <<'EOF'
 #!/usr/bin/env bash
-printf '4.3'
+set -euo pipefail
+args=" $* "
+printf 'R\n' >>"${CLIR_TEST_PROBE_COUNT:-/dev/null}"
+startup_r_libs="${R_LIBS-}"
+startup_r_libs_user="${R_LIBS_USER-}"
+if [[ "${args}" != *'--no-environ'* &&
+  "${args}" != *'--vanilla'* &&
+  -f "${HOME}/.Renviron" ]]; then
+  renviron_r_libs=$(sed -ne 's/^R_LIBS=//p' "${HOME}/.Renviron")
+  renviron_r_libs_user=$(sed -ne 's/^R_LIBS_USER=//p' "${HOME}/.Renviron")
+  [[ -z "${renviron_r_libs}" ]] || startup_r_libs="${renviron_r_libs}"
+  [[ -z "${renviron_r_libs_user}" ]] || startup_r_libs_user="${renviron_r_libs_user}"
+fi
+if [[ "${args}" = *' -e '* ]]; then
+  printf '%s\034%s\0344.3' "${startup_r_libs}" "${startup_r_libs_user}"
+else
+  printf 'R version 4.3.0\n'
+fi
 EOF
 cat >"${fake_bin}/Rscript" <<'EOF'
 #!/usr/bin/env bash
+printf 'Rscript\n' >>"${CLIR_TEST_PROBE_COUNT:-/dev/null}"
 printf '%s\n' "${R_LIBS_USER-UNSET}" >"${CLIR_TEST_RECORD}"
 printf '%s\n' "${R_LIBS-UNSET}" >>"${CLIR_TEST_RECORD}"
 EOF
 chmod +x "${fake_bin}/R" "${fake_bin}/Rscript"
 
 launcher_record="${test_root}/launcher-env"
+launcher_probe_count="${test_root}/launcher-probes"
+: >"${launcher_probe_count}"
 env -u R_LIBS_USER -u R_LIBS \
+  HOME="${test_root}" \
   CLIR_TEST_RECORD="${launcher_record}" \
+  CLIR_TEST_PROBE_COUNT="${launcher_probe_count}" \
   PATH="${fake_bin}:${PATH}" \
   "${cli}" --version
 grep -Fxq "${test_root}/r/4.3/library" "${launcher_record}"
+[[ "$(grep -c '^R$' "${launcher_probe_count}")" = 1 ]]
+[[ "$(grep -c '^Rscript$' "${launcher_probe_count}")" = 1 ]]
 
 probe_root="${test_root}/default-library-probe"
 mkdir -p "${probe_root}/bin" "${probe_root}/src"
@@ -56,35 +80,65 @@ env -u R_LIBS_USER -u R_LIBS \
   CLIR_EXPECTED_LIBRARY="${probe_library}" \
   "${probe_root}/bin/clir" --version
 
+: >"${launcher_probe_count}"
 env -u R_LIBS \
   R_LIBS_USER='NULL' \
+  HOME="${test_root}" \
   CLIR_TEST_RECORD="${launcher_record}" \
+  CLIR_TEST_PROBE_COUNT="${launcher_probe_count}" \
   PATH="${fake_bin}:${PATH}" \
   "${cli}" --version
 grep -Fxq "${test_root}/r/4.3/library" "${launcher_record}"
+[[ "$(grep -c '^R$' "${launcher_probe_count}")" = 1 ]]
+[[ "$(grep -c '^Rscript$' "${launcher_probe_count}")" = 1 ]]
 
+: >"${launcher_probe_count}"
 env R_LIBS_USER='NULL' R_LIBS='NULL' \
+  HOME="${test_root}" \
   CLIR_TEST_RECORD="${launcher_record}" \
+  CLIR_TEST_PROBE_COUNT="${launcher_probe_count}" \
   PATH="${fake_bin}:${PATH}" \
   "${cli}" --version
 grep -Fxq "${test_root}/r/4.3/library" "${launcher_record}"
+[[ "$(grep -c '^R$' "${launcher_probe_count}")" = 1 ]]
+[[ "$(grep -c '^Rscript$' "${launcher_probe_count}")" = 1 ]]
 
 explicit_user="${test_root}/explicit-user"
+: >"${launcher_probe_count}"
 env -u R_LIBS \
   R_LIBS_USER="${explicit_user}" \
+  HOME="${test_root}" \
   CLIR_TEST_RECORD="${launcher_record}" \
   PATH="${fake_bin}:${PATH}" \
   "${cli}" --version
 grep -Fxq "${explicit_user}" "${launcher_record}"
+[[ ! -s "${launcher_probe_count}" ]]
 
 explicit_r_lib="${test_root}/explicit-r"
+: >"${launcher_probe_count}"
 env -u R_LIBS_USER \
   R_LIBS="${explicit_r_lib}" \
+  HOME="${test_root}" \
   CLIR_TEST_RECORD="${launcher_record}" \
   PATH="${fake_bin}:${PATH}" \
   "${cli}" --version
 [[ "$(sed -n '1p' "${launcher_record}")" = 'NULL' ]]
 [[ "$(sed -n '2p' "${launcher_record}")" = "${explicit_r_lib}" ]]
+[[ ! -s "${launcher_probe_count}" ]]
+
+same_default_user=$(env -u R_LIBS_USER -u R_LIBS HOME="${test_root}" \
+  R --vanilla --slave -e 'cat(normalizePath(Sys.getenv("R_LIBS_USER"), mustWork = FALSE))')
+printf 'R_LIBS_USER=%s\n' "${same_default_user}" >"${test_root}/.Renviron"
+: >"${launcher_probe_count}"
+env -u R_LIBS_USER -u R_LIBS \
+  HOME="${test_root}" \
+  CLIR_TEST_RECORD="${launcher_record}" \
+  CLIR_TEST_PROBE_COUNT="${launcher_probe_count}" \
+  PATH="${fake_bin}:${PATH}" \
+  "${cli}" --version
+grep -Fxq "${same_default_user}" "${launcher_record}"
+[[ "$(grep -c '^R$' "${launcher_probe_count}")" = 1 ]]
+[[ "$(grep -c '^Rscript$' "${launcher_probe_count}")" = 1 ]]
 
 installer_root="${test_root}/installer-source"
 installer_fake_bin="${test_root}/installer-fake-bin"
@@ -108,14 +162,24 @@ if [[ "${1:-}" = '--version' ]]; then
   exit 0
 fi
 args=" $* "
-startup_env_library="${CLIR_TEST_DEFAULT_LIBRARY}"
+startup_r_libs="${R_LIBS-}"
+startup_r_libs_user="${R_LIBS_USER-}"
 if [[ "${args}" != *'--no-environ'* &&
   "${args}" != *'--vanilla'* &&
   -f "${HOME}/.Renviron" ]]; then
-  renviron_library=$(sed -ne 's/^R_LIBS_USER=//p' "${HOME}/.Renviron")
-  if [[ -n "${renviron_library}" ]]; then
-    startup_env_library="${renviron_library}"
-  fi
+  renviron_r_libs=$(sed -ne 's/^R_LIBS=//p' "${HOME}/.Renviron")
+  renviron_r_libs_user=$(sed -ne 's/^R_LIBS_USER=//p' "${HOME}/.Renviron")
+  [[ -z "${renviron_r_libs}" ]] || startup_r_libs="${renviron_r_libs}"
+  [[ -z "${renviron_r_libs_user}" ]] || startup_r_libs_user="${renviron_r_libs_user}"
+fi
+if [[ -n "${startup_r_libs}" && "${startup_r_libs}" != 'NULL' &&
+  "${startup_r_libs}" != '__clir_r_libs_probe_'* ]]; then
+  resolved_library="${startup_r_libs}"
+elif [[ -n "${startup_r_libs_user}" && "${startup_r_libs_user}" != 'NULL' &&
+  "${startup_r_libs_user}" != '__clir_r_libs_user_probe_'* ]]; then
+  resolved_library="${startup_r_libs_user}"
+else
+  resolved_library="${CLIR_TEST_DEFAULT_LIBRARY}"
 fi
 if [[ "${args}" != *'--no-init-file'* &&
   "${args}" != *'--vanilla'* &&
@@ -125,18 +189,12 @@ if [[ "${args}" != *'--no-init-file'* &&
   touch "${CLIR_TEST_PROBE_MARKER}"
 fi
 if [[ "${args}" = *' -e '* ]]; then
-  if [[ "${args}" = *'R.version'* ]]; then
-    printf '4.3'
-  elif [[ "${args}" = *'collapse'* ]]; then
-    if [[ "${args}" = *'--vanilla'* ]]; then
-      printf '\034%s' "${CLIR_TEST_DEFAULT_LIBRARY}"
-    else
-      printf '\034%s' "${startup_env_library}"
-    fi
-  elif [[ "${args}" = *'paths <-'* && "${args}" = *'--vanilla'* ]]; then
-    printf '%s' "${CLIR_TEST_MANAGED_LIBRARY}"
+  if [[ "${args}" = *'collapse'* && "${args}" = *'R.version'* ]]; then
+    printf '%s\034%s\0344.3' "${startup_r_libs}" "${startup_r_libs_user}"
   elif [[ "${args}" = *'paths <-'* ]]; then
-    printf '%s' "${startup_env_library}"
+    printf '%s' "${resolved_library}"
+  elif [[ "${args}" = *'R.version'* ]]; then
+    printf '4.3'
   elif [[ "${args}" = *'--vanilla'* ]]; then
     printf '%s' "${CLIR_TEST_MANAGED_LIBRARY}"
   else
@@ -181,6 +239,20 @@ PATH="${installer_fake_bin}:${PATH}" \
 [[ ! -e "${test_root}/probe-profile-marker" ]]
 [[ -f "${test_root}/runtime-profile-marker" ]]
 
+printf 'R_LIBS_USER=%s\n' "${installer_default_library}" >"${test_root}/.Renviron"
+env -u R_LIBS_USER -u R_LIBS \
+CLIR_SOURCE_DIR="${installer_root}" \
+CLIR_TEST_ENV_LIBRARY="${installer_default_library}" \
+CLIR_TEST_MANAGED_LIBRARY="${installer_managed_library}" \
+CLIR_TEST_DEFAULT_LIBRARY="${installer_default_library}" \
+CLIR_TEST_ENV_MARKER="${installer_marker}" \
+CLIR_TEST_MANAGED_MARKER="${test_root}/managed-marker" \
+CLIR_TEST_PROBE_MARKER="${test_root}/probe-profile-marker" \
+CLIR_TEST_PROFILE_MARKER="${test_root}/runtime-profile-marker" \
+HOME="${test_root}" \
+PATH="${installer_fake_bin}:${PATH}" \
+  "${installer_root}/install_clir.sh" --debug
+
 if [[ -n "${R_LIBS_USER:-}" ]]; then
   cli_env=("R_LIBS_USER=${R_LIBS_USER}")
 elif [[ -n "${R_LIBS:-}" ]]; then
@@ -192,6 +264,8 @@ fi
 run_cli() {
   env "${cli_env[@]}" "${cli}" "${@}"
 }
+
+[[ "$(run_cli --version)" = 'v2.0.0' ]]
 
 help_output=$(run_cli --help)
 grep -Fq 'pak' <<<"${help_output}"

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -162,7 +162,7 @@ env -u R_LIBS_USER \
   CLIR_TEST_PROBE_COUNT="${launcher_probe_count}" \
   PATH="${fake_bin}:${PATH}" \
   "${cli}" --version
-[[ "$(sed -n '1p' "${launcher_record}")" = 'NULL' ]]
+[[ "$(sed -n '1p' "${launcher_record}")" != 'NULL' ]]
 [[ "$(sed -n '2p' "${launcher_record}")" = "${explicit_r_lib}" ]]
 [[ "$(grep -c '^R$' "${launcher_probe_count}")" = 0 ]]
 [[ "$(grep -c '^Rscript$' "${launcher_probe_count}")" = 1 ]]
@@ -206,7 +206,7 @@ env -u R_LIBS_USER -u R_LIBS \
   CLIR_TEST_VANILLA_USER="${conditional_system_user}" \
   PATH="${fake_bin}:${PATH}" \
   "${cli}" --version
-[[ "$(sed -n '1p' "${launcher_record}")" = 'NULL' ]]
+[[ "$(sed -n '1p' "${launcher_record}")" != 'NULL' ]]
 [[ "$(sed -n '2p' "${launcher_record}")" = 'conditional-r-default' ]]
 [[ "$(grep -c '^R$' "${launcher_probe_count}")" = 2 ]]
 [[ "$(grep -c '^Rscript$' "${launcher_probe_count}")" = 1 ]]
@@ -221,7 +221,7 @@ env -u R_LIBS_USER -u R_LIBS \
   CLIR_TEST_VANILLA_USER="${conditional_system_user}" \
   PATH="${fake_bin}:${PATH}" \
   "${cli}" --version
-[[ "$(sed -n '1p' "${launcher_record}")" = 'NULL' ]]
+[[ "$(sed -n '1p' "${launcher_record}")" != 'NULL' ]]
 [[ "$(sed -n '2p' "${launcher_record}")" = 'conditional-r-default' ]]
 [[ "$(grep -c '^R$' "${launcher_probe_count}")" = 2 ]]
 [[ "$(grep -c '^Rscript$' "${launcher_probe_count}")" = 1 ]]

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+test_root=$(mktemp -d)
+trap 'rm -rf "${test_root}"' EXIT
+
+mkdir -p "${test_root}/bin" "${test_root}/src"
+cp "${repo_root}/src/clir.R" "${test_root}/src/clir.R"
+cp "${repo_root}/src/util.R" "${test_root}/src/util.R"
+ln -s ../src/clir.R "${test_root}/bin/clir"
+
+cli="${test_root}/bin/clir"
+Rscript "${cli}" --version | grep -Fq 'v1.2.1'
+Rscript "${cli}" --help | grep -Fq 'pak'
+Rscript "${cli}" config --init >"${test_root}/config.out"
+grep -Fq 'repos' "${test_root}/r/clir.yml"
+
+Rscript "${cli}" cran https://example.invalid/cran >/dev/null
+grep -Fq 'https://example.invalid/cran' "${test_root}/r/clir.yml"
+
+if Rscript "${cli}" drat example >/dev/null 2>&1; then
+  echo 'removed drat command was accepted' >&2
+  exit 1
+fi
+if Rscript "${cli}" install --devt=cran example >/dev/null 2>&1; then
+  echo 'removed --devt option was accepted' >&2
+  exit 1
+fi
+if Rscript "${cli}" install --bioc example >/dev/null 2>&1; then
+  echo 'removed --bioc option was accepted' >&2
+  exit 1
+fi
+
+if Rscript "${cli}" --invalid-option >/dev/null 2>&1; then
+  echo 'invalid option was accepted' >&2
+  exit 1
+fi
+
+echo 'All CLI tests passed.'

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -99,7 +99,7 @@ cp "${repo_root}/src/clir.R" "${installer_root}/src/clir.R"
 cp "${repo_root}/src/util.R" "${installer_root}/src/util.R"
 chmod +x "${installer_root}/install_clir.sh" "${installer_root}/bin/clir"
 printf 'R_LIBS_USER=%s\n' "${installer_env_library}" >"${test_root}/.Renviron"
-printf '# noisy profile regression\n' >"${test_root}/.Rprofile"
+printf '# CLIR_TEST_PROFILE=enabled\n' >"${test_root}/.Rprofile"
 cat >"${installer_fake_bin}/R" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -108,9 +108,19 @@ if [[ "${1:-}" = '--version' ]]; then
   exit 0
 fi
 args=" $* "
+startup_env_library="${CLIR_TEST_DEFAULT_LIBRARY}"
+if [[ "${args}" != *'--no-environ'* &&
+  "${args}" != *'--vanilla'* &&
+  -f "${HOME}/.Renviron" ]]; then
+  renviron_library=$(sed -ne 's/^R_LIBS_USER=//p' "${HOME}/.Renviron")
+  if [[ -n "${renviron_library}" ]]; then
+    startup_env_library="${renviron_library}"
+  fi
+fi
 if [[ "${args}" != *'--no-init-file'* &&
   "${args}" != *'--vanilla'* &&
-  -f "${HOME}/.Rprofile" ]]; then
+  -f "${HOME}/.Rprofile" &&
+  grep -Fq 'CLIR_TEST_PROFILE=enabled' "${HOME}/.Rprofile" ]]; then
   printf 'profile-noise'
   touch "${CLIR_TEST_PROBE_MARKER}"
 fi
@@ -121,12 +131,12 @@ if [[ "${args}" = *' -e '* ]]; then
     if [[ "${args}" = *'--vanilla'* ]]; then
       printf '\034%s' "${CLIR_TEST_DEFAULT_LIBRARY}"
     else
-      printf '\034%s' "${CLIR_TEST_ENV_LIBRARY}"
+      printf '\034%s' "${startup_env_library}"
     fi
   elif [[ "${args}" = *'paths <-'* && "${args}" = *'--vanilla'* ]]; then
     printf '%s' "${CLIR_TEST_MANAGED_LIBRARY}"
   elif [[ "${args}" = *'paths <-'* ]]; then
-    printf '%s' "${CLIR_TEST_ENV_LIBRARY}"
+    printf '%s' "${startup_env_library}"
   elif [[ "${args}" = *'--vanilla'* ]]; then
     printf '%s' "${CLIR_TEST_MANAGED_LIBRARY}"
   else
@@ -141,7 +151,11 @@ EOF
 cat >"${installer_fake_bin}/Rscript" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
-if [[ -f "${HOME}/.Rprofile" ]]; then
+args=" $* "
+if [[ "${args}" != *'--no-init-file'* &&
+  "${args}" != *'--vanilla'* &&
+  -f "${HOME}/.Rprofile" &&
+  grep -Fq 'CLIR_TEST_PROFILE=enabled' "${HOME}/.Rprofile" ]]; then
   touch "${CLIR_TEST_PROFILE_MARKER}"
 fi
 [[ "${R_LIBS_USER:-}" = "${CLIR_TEST_ENV_LIBRARY}" ]]

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -22,16 +22,53 @@ args=" $* "
 printf 'R\n' >>"${CLIR_TEST_PROBE_COUNT:-/dev/null}"
 startup_r_libs="${R_LIBS-}"
 startup_r_libs_user="${R_LIBS_USER-}"
+startup_library_assignment=0
+r_libs_set=0
+r_libs_user_set=0
+[[ ${R_LIBS+x} = x ]] && r_libs_set=1
+[[ ${R_LIBS_USER+x} = x ]] && r_libs_user_set=1
+if [[ -n "${CLIR_TEST_VANILLA_USER:-}" ]]; then
+  startup_r_libs_user="${CLIR_TEST_VANILLA_USER}"
+  r_libs_user_set=1
+fi
+apply_renviron_value() {
+  local variable="${1}"
+  local value="${2}"
+  if [[ "${variable}" = 'R_LIBS' ]]; then
+    if [[ "${value}" = '${R_LIBS-default}' ]]; then
+      [[ ${r_libs_set} -eq 1 ]] || startup_r_libs='conditional-r-default'
+    elif [[ "${value}" = '${R_LIBS:-default}' ]]; then
+      [[ -n "${startup_r_libs}" ]] || startup_r_libs='conditional-r-default'
+    else
+      startup_r_libs="${value}"
+    fi
+    r_libs_set=1
+  else
+    if [[ "${value}" = '${R_LIBS_USER-default}' ]]; then
+      [[ ${r_libs_user_set} -eq 1 ]] || startup_r_libs_user='conditional-user-default'
+    elif [[ "${value}" = '${R_LIBS_USER:-default}' ]]; then
+      [[ -n "${startup_r_libs_user}" ]] || startup_r_libs_user='conditional-user-default'
+    else
+      startup_r_libs_user="${value}"
+    fi
+    r_libs_user_set=1
+  fi
+}
 if [[ "${args}" != *'--no-environ'* &&
   "${args}" != *'--vanilla'* &&
+  "${R_ENVIRON_USER:-}" != '/dev/null' &&
   -f "${HOME}/.Renviron" ]]; then
   renviron_r_libs=$(sed -ne 's/^R_LIBS=//p' "${HOME}/.Renviron")
   renviron_r_libs_user=$(sed -ne 's/^R_LIBS_USER=//p' "${HOME}/.Renviron")
-  [[ -z "${renviron_r_libs}" ]] || startup_r_libs="${renviron_r_libs}"
-  [[ -z "${renviron_r_libs_user}" ]] || startup_r_libs_user="${renviron_r_libs_user}"
+  [[ -z "${renviron_r_libs}" && -z "${renviron_r_libs_user}" ]] || startup_library_assignment=1
+  [[ -z "${renviron_r_libs}" ]] || apply_renviron_value R_LIBS "${renviron_r_libs}"
+  [[ -z "${renviron_r_libs_user}" ]] || apply_renviron_value R_LIBS_USER "${renviron_r_libs_user}"
+fi
+if [[ "${args}" = *'--vanilla'* && -n "${CLIR_TEST_VANILLA_USER:-}" ]]; then
+  startup_r_libs_user="${CLIR_TEST_VANILLA_USER}"
 fi
 if [[ "${args}" = *' -e '* ]]; then
-  printf '%s\034%s\0344.3' "${startup_r_libs}" "${startup_r_libs_user}"
+  printf '%s\034%s\0344.3\034%s' "${startup_r_libs}" "${startup_r_libs_user}" "${startup_library_assignment}"
 else
   printf 'R version 4.3.0\n'
 fi
@@ -54,7 +91,7 @@ env -u R_LIBS_USER -u R_LIBS \
   PATH="${fake_bin}:${PATH}" \
   "${cli}" --version
 grep -Fxq "${test_root}/r/4.3/library" "${launcher_record}"
-[[ "$(grep -c '^R$' "${launcher_probe_count}")" = 1 ]]
+[[ "$(grep -c '^R$' "${launcher_probe_count}")" = 2 ]]
 [[ "$(grep -c '^Rscript$' "${launcher_probe_count}")" = 1 ]]
 
 probe_root="${test_root}/default-library-probe"
@@ -89,7 +126,7 @@ env -u R_LIBS \
   PATH="${fake_bin}:${PATH}" \
   "${cli}" --version
 grep -Fxq "${test_root}/r/4.3/library" "${launcher_record}"
-[[ "$(grep -c '^R$' "${launcher_probe_count}")" = 1 ]]
+[[ "$(grep -c '^R$' "${launcher_probe_count}")" = 2 ]]
 [[ "$(grep -c '^Rscript$' "${launcher_probe_count}")" = 1 ]]
 
 : >"${launcher_probe_count}"
@@ -100,7 +137,7 @@ env R_LIBS_USER='NULL' R_LIBS='NULL' \
   PATH="${fake_bin}:${PATH}" \
   "${cli}" --version
 grep -Fxq "${test_root}/r/4.3/library" "${launcher_record}"
-[[ "$(grep -c '^R$' "${launcher_probe_count}")" = 1 ]]
+[[ "$(grep -c '^R$' "${launcher_probe_count}")" = 2 ]]
 [[ "$(grep -c '^Rscript$' "${launcher_probe_count}")" = 1 ]]
 
 explicit_user="${test_root}/explicit-user"
@@ -109,10 +146,12 @@ env -u R_LIBS \
   R_LIBS_USER="${explicit_user}" \
   HOME="${test_root}" \
   CLIR_TEST_RECORD="${launcher_record}" \
+  CLIR_TEST_PROBE_COUNT="${launcher_probe_count}" \
   PATH="${fake_bin}:${PATH}" \
   "${cli}" --version
 grep -Fxq "${explicit_user}" "${launcher_record}"
-[[ ! -s "${launcher_probe_count}" ]]
+[[ "$(grep -c '^R$' "${launcher_probe_count}")" = 0 ]]
+[[ "$(grep -c '^Rscript$' "${launcher_probe_count}")" = 1 ]]
 
 explicit_r_lib="${test_root}/explicit-r"
 : >"${launcher_probe_count}"
@@ -120,24 +159,88 @@ env -u R_LIBS_USER \
   R_LIBS="${explicit_r_lib}" \
   HOME="${test_root}" \
   CLIR_TEST_RECORD="${launcher_record}" \
+  CLIR_TEST_PROBE_COUNT="${launcher_probe_count}" \
   PATH="${fake_bin}:${PATH}" \
   "${cli}" --version
 [[ "$(sed -n '1p' "${launcher_record}")" = 'NULL' ]]
 [[ "$(sed -n '2p' "${launcher_record}")" = "${explicit_r_lib}" ]]
-[[ ! -s "${launcher_probe_count}" ]]
+[[ "$(grep -c '^R$' "${launcher_probe_count}")" = 0 ]]
+[[ "$(grep -c '^Rscript$' "${launcher_probe_count}")" = 1 ]]
 
-same_default_user=$(env -u R_LIBS_USER -u R_LIBS HOME="${test_root}" \
-  R --vanilla --slave -e 'cat(normalizePath(Sys.getenv("R_LIBS_USER"), mustWork = FALSE))')
-printf 'R_LIBS_USER=%s\n' "${same_default_user}" >"${test_root}/.Renviron"
+# shellcheck disable=SC2016
+printf 'R_LIBS_USER=${R_LIBS_USER-default}\n' >"${test_root}/.Renviron"
+conditional_system_user="${test_root}/system-user-default"
 : >"${launcher_probe_count}"
 env -u R_LIBS_USER -u R_LIBS \
   HOME="${test_root}" \
   CLIR_TEST_RECORD="${launcher_record}" \
   CLIR_TEST_PROBE_COUNT="${launcher_probe_count}" \
+  CLIR_TEST_VANILLA_USER="${conditional_system_user}" \
+  PATH="${fake_bin}:${PATH}" \
+  "${cli}" --version
+grep -Fxq "${conditional_system_user}" "${launcher_record}"
+[[ "$(grep -c '^R$' "${launcher_probe_count}")" = 2 ]]
+[[ "$(grep -c '^Rscript$' "${launcher_probe_count}")" = 1 ]]
+
+# shellcheck disable=SC2016
+printf 'R_LIBS_USER=${R_LIBS_USER:-default}\n' >"${test_root}/.Renviron"
+: >"${launcher_probe_count}"
+env -u R_LIBS_USER -u R_LIBS \
+  HOME="${test_root}" \
+  CLIR_TEST_RECORD="${launcher_record}" \
+  CLIR_TEST_PROBE_COUNT="${launcher_probe_count}" \
+  CLIR_TEST_VANILLA_USER="${conditional_system_user}" \
+  PATH="${fake_bin}:${PATH}" \
+  "${cli}" --version
+grep -Fxq "${conditional_system_user}" "${launcher_record}"
+[[ "$(grep -c '^R$' "${launcher_probe_count}")" = 2 ]]
+[[ "$(grep -c '^Rscript$' "${launcher_probe_count}")" = 1 ]]
+
+# shellcheck disable=SC2016
+printf 'R_LIBS=${R_LIBS-default}\n' >"${test_root}/.Renviron"
+: >"${launcher_probe_count}"
+env -u R_LIBS_USER -u R_LIBS \
+  HOME="${test_root}" \
+  CLIR_TEST_RECORD="${launcher_record}" \
+  CLIR_TEST_PROBE_COUNT="${launcher_probe_count}" \
+  CLIR_TEST_VANILLA_USER="${conditional_system_user}" \
+  PATH="${fake_bin}:${PATH}" \
+  "${cli}" --version
+[[ "$(sed -n '1p' "${launcher_record}")" = 'NULL' ]]
+[[ "$(sed -n '2p' "${launcher_record}")" = 'conditional-r-default' ]]
+[[ "$(grep -c '^R$' "${launcher_probe_count}")" = 2 ]]
+[[ "$(grep -c '^Rscript$' "${launcher_probe_count}")" = 1 ]]
+
+# shellcheck disable=SC2016
+printf 'R_LIBS=${R_LIBS:-default}\n' >"${test_root}/.Renviron"
+: >"${launcher_probe_count}"
+env -u R_LIBS_USER -u R_LIBS \
+  HOME="${test_root}" \
+  CLIR_TEST_RECORD="${launcher_record}" \
+  CLIR_TEST_PROBE_COUNT="${launcher_probe_count}" \
+  CLIR_TEST_VANILLA_USER="${conditional_system_user}" \
+  PATH="${fake_bin}:${PATH}" \
+  "${cli}" --version
+[[ "$(sed -n '1p' "${launcher_record}")" = 'NULL' ]]
+[[ "$(sed -n '2p' "${launcher_record}")" = 'conditional-r-default' ]]
+[[ "$(grep -c '^R$' "${launcher_probe_count}")" = 2 ]]
+[[ "$(grep -c '^Rscript$' "${launcher_probe_count}")" = 1 ]]
+
+same_default_user=$(env -u R_LIBS_USER -u R_LIBS -u R_ENVIRON_USER -u R_PROFILE_USER \
+  HOME="${test_root}" \
+  R --vanilla --slave -e 'cat(normalizePath(Sys.getenv("R_LIBS_USER"), mustWork = FALSE))')
+printf 'R_LIBS_USER=%s\n' "${same_default_user}" >"${test_root}/.Renviron"
+: >"${launcher_probe_count}"
+env -u R_LIBS_USER -u R_LIBS \
+  -u R_ENVIRON_USER -u R_PROFILE_USER \
+  HOME="${test_root}" \
+  CLIR_TEST_RECORD="${launcher_record}" \
+  CLIR_TEST_PROBE_COUNT="${launcher_probe_count}" \
+  CLIR_TEST_VANILLA_USER="${same_default_user}" \
   PATH="${fake_bin}:${PATH}" \
   "${cli}" --version
 grep -Fxq "${same_default_user}" "${launcher_record}"
-[[ "$(grep -c '^R$' "${launcher_probe_count}")" = 1 ]]
+[[ "$(grep -c '^R$' "${launcher_probe_count}")" = 2 ]]
 [[ "$(grep -c '^Rscript$' "${launcher_probe_count}")" = 1 ]]
 
 installer_root="${test_root}/installer-source"
@@ -146,6 +249,8 @@ installer_env_library="${test_root}/renviron-library"
 installer_managed_library="${installer_root}/r/4.3/library"
 installer_default_library="${test_root}/default-user-library"
 installer_marker="${test_root}/installed-marker"
+installer_bootstrap_marker="${test_root}/bootstrap-marker"
+installer_link_marker="${test_root}/link-marker"
 mkdir -p "${installer_root}/bin" "${installer_root}/src" "${installer_fake_bin}"
 cp "${repo_root}/install_clir.sh" "${installer_root}/install_clir.sh"
 cp "${repo_root}/bin/clir" "${installer_root}/bin/clir"
@@ -164,11 +269,14 @@ fi
 args=" $* "
 startup_r_libs="${R_LIBS-}"
 startup_r_libs_user="${R_LIBS_USER-}"
+startup_library_assignment=0
 if [[ "${args}" != *'--no-environ'* &&
   "${args}" != *'--vanilla'* &&
+  "${R_ENVIRON_USER:-}" != '/dev/null' &&
   -f "${HOME}/.Renviron" ]]; then
   renviron_r_libs=$(sed -ne 's/^R_LIBS=//p' "${HOME}/.Renviron")
   renviron_r_libs_user=$(sed -ne 's/^R_LIBS_USER=//p' "${HOME}/.Renviron")
+  [[ -z "${renviron_r_libs}" && -z "${renviron_r_libs_user}" ]] || startup_library_assignment=1
   [[ -z "${renviron_r_libs}" ]] || startup_r_libs="${renviron_r_libs}"
   [[ -z "${renviron_r_libs_user}" ]] || startup_r_libs_user="${renviron_r_libs_user}"
 fi
@@ -183,6 +291,7 @@ else
 fi
 if [[ "${args}" != *'--no-init-file'* &&
   "${args}" != *'--vanilla'* &&
+  "${R_PROFILE_USER:-}" != '/dev/null' &&
   -f "${HOME}/.Rprofile" ]] &&
   grep -Fq 'CLIR_TEST_PROFILE=enabled' "${HOME}/.Rprofile"; then
   printf 'profile-noise'
@@ -190,8 +299,8 @@ if [[ "${args}" != *'--no-init-file'* &&
 fi
 if [[ "${args}" = *' -e '* ]]; then
   if [[ "${args}" = *'collapse'* && "${args}" = *'R.version'* ]]; then
-    printf '%s\034%s\0344.3' "${startup_r_libs}" "${startup_r_libs_user}"
-  elif [[ "${args}" = *'paths <-'* ]]; then
+    printf '%s\034%s\0344.3\034%s' "${startup_r_libs}" "${startup_r_libs_user}" "${startup_library_assignment}"
+  elif [[ "${args}" = *'paths <-'* || "${args}" = *'resolve_r_library'* ]]; then
     printf '%s' "${resolved_library}"
   elif [[ "${args}" = *'R.version'* ]]; then
     printf '4.3'
@@ -202,6 +311,8 @@ if [[ "${args}" = *' -e '* ]]; then
   fi
 elif [[ "${args}" = *'--vanilla'* ]]; then
   touch "${CLIR_TEST_MANAGED_MARKER}"
+elif [[ "${args}" = *'--no-environ'* ]]; then
+  touch "${CLIR_TEST_BOOTSTRAP_MARKER}"
 else
   touch "${CLIR_TEST_ENV_MARKER}"
 fi
@@ -210,31 +321,46 @@ cat >"${installer_fake_bin}/Rscript" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 args=" $* "
+expected_library="${CLIR_TEST_EXPECTED_LIBRARY:-${CLIR_TEST_ENV_LIBRARY}}"
 [[ "${args}" != *' -d '* ]]
-[[ "${CLIR_R_LIBS_USER:-}" = "${CLIR_TEST_ENV_LIBRARY}" ]]
+selected_library="${R_LIBS_USER:-}"
+if [[ -z "${selected_library}" || "${selected_library}" = 'NULL' ]]; then
+  selected_library="${R_LIBS-}"
+fi
+[[ "${CLIR_R_LIBS_USER:-}" = "${R_LIBS_USER-}" ]]
+[[ "${CLIR_R_LIBS:-}" = "${R_LIBS-}" ]]
 if [[ "${args}" != *'--no-init-file'* &&
   "${args}" != *'--vanilla'* &&
+  "${R_PROFILE_USER:-}" != '/dev/null' &&
   -f "${HOME}/.Rprofile" ]] &&
   grep -Fq 'CLIR_TEST_PROFILE=enabled' "${HOME}/.Rprofile"; then
   touch "${CLIR_TEST_PROFILE_MARKER}"
 fi
-[[ "${R_LIBS_USER:-}" = "${CLIR_TEST_ENV_LIBRARY}" ]]
-[[ -f "${CLIR_TEST_ENV_MARKER}" ]]
+[[ "${selected_library}" = "${expected_library}" ]]
+expected_marker="${CLIR_TEST_EXPECTED_MARKER:-${CLIR_TEST_ENV_MARKER}}"
+[[ -f "${expected_marker}" ]]
 EOF
 chmod +x "${installer_fake_bin}/R" "${installer_fake_bin}/Rscript"
+cat >"${installer_fake_bin}/ln" <<'EOF'
+#!/usr/bin/env bash
+touch "${CLIR_TEST_LINK_MARKER}"
+EOF
+chmod +x "${installer_fake_bin}/ln"
 env -u R_LIBS_USER -u R_LIBS \
 CLIR_SOURCE_DIR="${installer_root}" \
 CLIR_TEST_ENV_LIBRARY="${installer_env_library}" \
 CLIR_TEST_MANAGED_LIBRARY="${installer_managed_library}" \
 CLIR_TEST_DEFAULT_LIBRARY="${installer_default_library}" \
 CLIR_TEST_ENV_MARKER="${installer_marker}" \
+CLIR_TEST_BOOTSTRAP_MARKER="${installer_bootstrap_marker}" \
+CLIR_TEST_EXPECTED_MARKER="${installer_bootstrap_marker}" \
 CLIR_TEST_MANAGED_MARKER="${test_root}/managed-marker" \
 CLIR_TEST_PROBE_MARKER="${test_root}/probe-profile-marker" \
 CLIR_TEST_PROFILE_MARKER="${test_root}/runtime-profile-marker" \
 HOME="${test_root}" \
 PATH="${installer_fake_bin}:${PATH}" \
   "${installer_root}/install_clir.sh" --debug
-[[ -f "${installer_marker}" ]]
+[[ -f "${installer_bootstrap_marker}" ]]
 [[ ! -e "${test_root}/managed-marker" ]]
 [[ ! -e "${test_root}/probe-profile-marker" ]]
 [[ -f "${test_root}/runtime-profile-marker" ]]
@@ -246,12 +372,81 @@ CLIR_TEST_ENV_LIBRARY="${installer_default_library}" \
 CLIR_TEST_MANAGED_LIBRARY="${installer_managed_library}" \
 CLIR_TEST_DEFAULT_LIBRARY="${installer_default_library}" \
 CLIR_TEST_ENV_MARKER="${installer_marker}" \
+CLIR_TEST_BOOTSTRAP_MARKER="${installer_bootstrap_marker}" \
+CLIR_TEST_EXPECTED_MARKER="${installer_bootstrap_marker}" \
 CLIR_TEST_MANAGED_MARKER="${test_root}/managed-marker" \
 CLIR_TEST_PROBE_MARKER="${test_root}/probe-profile-marker" \
 CLIR_TEST_PROFILE_MARKER="${test_root}/runtime-profile-marker" \
 HOME="${test_root}" \
 PATH="${installer_fake_bin}:${PATH}" \
   "${installer_root}/install_clir.sh" --debug
+
+shell_user_library="${test_root}/shell-user-library"
+printf 'R_LIBS_USER=%s\n' "${installer_env_library}" >"${test_root}/.Renviron"
+rm -f "${installer_bootstrap_marker}" "${test_root}/runtime-profile-marker"
+env -u R_LIBS \
+CLIR_SOURCE_DIR="${installer_root}" \
+CLIR_TEST_ENV_LIBRARY="${installer_env_library}" \
+CLIR_TEST_EXPECTED_LIBRARY="${shell_user_library}" \
+CLIR_TEST_MANAGED_LIBRARY="${installer_managed_library}" \
+CLIR_TEST_DEFAULT_LIBRARY="${installer_default_library}" \
+CLIR_TEST_ENV_MARKER="${installer_marker}" \
+CLIR_TEST_BOOTSTRAP_MARKER="${installer_bootstrap_marker}" \
+CLIR_TEST_EXPECTED_MARKER="${installer_bootstrap_marker}" \
+CLIR_TEST_MANAGED_MARKER="${test_root}/managed-marker" \
+CLIR_TEST_PROBE_MARKER="${test_root}/probe-profile-marker" \
+CLIR_TEST_PROFILE_MARKER="${test_root}/runtime-profile-marker" \
+HOME="${test_root}" \
+R_LIBS_USER="${shell_user_library}" \
+PATH="${installer_fake_bin}:${PATH}" \
+  "${installer_root}/install_clir.sh" --debug
+
+shell_r_library="${test_root}/shell-r-library"
+rm -f "${installer_bootstrap_marker}" "${test_root}/runtime-profile-marker"
+env -u R_LIBS_USER \
+CLIR_SOURCE_DIR="${installer_root}" \
+CLIR_TEST_ENV_LIBRARY="${installer_env_library}" \
+CLIR_TEST_EXPECTED_LIBRARY="${shell_r_library}" \
+CLIR_TEST_MANAGED_LIBRARY="${installer_managed_library}" \
+CLIR_TEST_DEFAULT_LIBRARY="${installer_default_library}" \
+CLIR_TEST_ENV_MARKER="${installer_marker}" \
+CLIR_TEST_BOOTSTRAP_MARKER="${installer_bootstrap_marker}" \
+CLIR_TEST_EXPECTED_MARKER="${installer_bootstrap_marker}" \
+CLIR_TEST_MANAGED_MARKER="${test_root}/managed-marker" \
+CLIR_TEST_PROBE_MARKER="${test_root}/probe-profile-marker" \
+CLIR_TEST_PROFILE_MARKER="${test_root}/runtime-profile-marker" \
+HOME="${test_root}" \
+R_LIBS="${shell_r_library}" \
+PATH="${installer_fake_bin}:${PATH}" \
+  "${installer_root}/install_clir.sh" --debug
+
+rm -f "${installer_marker}" "${installer_bootstrap_marker}" \
+  "${installer_link_marker}" "${test_root}/managed-marker" \
+  "${test_root}/probe-profile-marker" "${test_root}/runtime-profile-marker"
+printf 'R_LIBS_USER=%s\n' "${installer_env_library}" >"${test_root}/.Renviron"
+printf 'CLIR_TEST_PROFILE=enabled\n' >"${test_root}/.Rprofile"
+env -u R_LIBS_USER -u R_LIBS \
+CLIR_SOURCE_DIR="${installer_root}" \
+CLIR_TEST_ENV_LIBRARY="${installer_env_library}" \
+CLIR_TEST_EXPECTED_LIBRARY="${installer_managed_library}" \
+CLIR_TEST_MANAGED_LIBRARY="${installer_managed_library}" \
+CLIR_TEST_DEFAULT_LIBRARY="${installer_managed_library}" \
+CLIR_TEST_ENV_MARKER="${installer_marker}" \
+CLIR_TEST_BOOTSTRAP_MARKER="${installer_bootstrap_marker}" \
+CLIR_TEST_EXPECTED_MARKER="${installer_bootstrap_marker}" \
+CLIR_TEST_LINK_MARKER="${installer_link_marker}" \
+CLIR_TEST_MANAGED_MARKER="${test_root}/managed-marker" \
+CLIR_TEST_PROBE_MARKER="${test_root}/probe-profile-marker" \
+CLIR_TEST_PROFILE_MARKER="${test_root}/runtime-profile-marker" \
+HOME="${test_root}" \
+PATH="${installer_fake_bin}:${PATH}" \
+  "${installer_root}/install_clir.sh" --root --debug
+[[ -f "${installer_link_marker}" ]]
+[[ -f "${installer_bootstrap_marker}" ]]
+[[ ! -e "${installer_marker}" ]]
+[[ ! -e "${test_root}/managed-marker" ]]
+[[ ! -e "${test_root}/probe-profile-marker" ]]
+[[ ! -e "${test_root}/runtime-profile-marker" ]]
 
 if [[ -n "${R_LIBS_USER:-}" ]]; then
   cli_env=("R_LIBS_USER=${R_LIBS_USER}")
@@ -261,11 +456,33 @@ else
   runtime_r_lib=$(R --vanilla --slave -e 'cat(.libPaths()[[1]])')
   cli_env=("R_LIBS_USER=${runtime_r_lib}")
 fi
+cli_home="${test_root}/cli-home"
+mkdir -p "${cli_home}"
 run_cli() {
-  env "${cli_env[@]}" "${cli}" "${@}"
+  env -u R_ENVIRON_USER -u R_PROFILE_USER -u R_PROFILE \
+    HOME="${cli_home}" "${cli_env[@]}" "${cli}" "${@}"
 }
 
 [[ "$(run_cli --version)" = 'v2.0.0' ]]
+
+profile_home="${test_root}/profile-home"
+profile_file="${test_root}/drop-selected-library.R"
+mkdir -p "${profile_home}"
+cat >"${profile_file}" <<'EOF'
+selected <- normalizePath(Sys.getenv("CLIR_TEST_SELECTED_LIBRARY"), mustWork = FALSE)
+.libPaths(setdiff(.libPaths(), selected))
+if (requireNamespace("docopt", quietly = TRUE)) {
+  stop("docopt is available outside the selected library")
+}
+EOF
+selected_library="${cli_env[0]#*=}"
+selected_library="${selected_library%%:*}"
+profile_version=$(env -u R_ENVIRON_USER -u R_PROFILE \
+  R_PROFILE_USER="${profile_file}" \
+  HOME="${profile_home}" \
+  CLIR_TEST_SELECTED_LIBRARY="${selected_library}" \
+  "${cli_env[@]}" "${cli}" --version)
+[[ "${profile_version}" = 'v2.0.0' ]]
 
 help_output=$(run_cli --help)
 grep -Fq 'pak' <<<"${help_output}"

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -33,6 +33,19 @@ env -u R_LIBS_USER -u R_LIBS \
   "${cli}" --version
 grep -Fxq "${test_root}/r/4.3/library" "${launcher_record}"
 
+probe_root="${test_root}/default-library-probe"
+mkdir -p "${probe_root}/bin" "${probe_root}/src"
+cp "${repo_root}/bin/clir" "${probe_root}/bin/clir"
+# shellcheck disable=SC2016
+probe_version=$(R --vanilla --slave -e 'cat(paste(R.version$major, strsplit(R.version$minor, ".", fixed = TRUE)[[1]][1], sep = "."))')
+probe_library="${probe_root}/r/${probe_version}/library"
+mkdir -p "${probe_library}"
+cat >"${probe_root}/src/clir.R" <<'EOF'
+cat(.libPaths()[[1]], "\n")
+EOF
+probe_result=$(env -u R_LIBS_USER -u R_LIBS "${probe_root}/bin/clir" --version)
+[[ "${probe_result}" = "${probe_library}" ]]
+
 env -u R_LIBS \
   R_LIBS_USER='NULL' \
   CLIR_TEST_RECORD="${launcher_record}" \
@@ -76,7 +89,12 @@ run_cli() {
 }
 
 run_cli --version | grep -Fq 'v1.2.1'
-run_cli --help | grep -Fq 'pak'
+help_output=$(run_cli --help)
+grep -Fq 'pak' <<<"${help_output}"
+if grep -Eq 'drat|--devt|--bioc' <<<"${help_output}"; then
+  echo 'removed interfaces remain in the CLI help' >&2
+  exit 1
+fi
 run_cli config --init >"${test_root}/config.out"
 grep -Fq 'repos' "${test_root}/r/clir.yml"
 

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -112,19 +112,17 @@ run_cli cran https://example.invalid/cran >/dev/null
 grep -Fq 'https://example.invalid/cran' "${test_root}/r/clir.yml"
 
 assert_parser_rejects() {
-  local expected output
-  expected=${1}
-  shift
+  local output
   if output=$(run_cli "$@" 2>&1); then
     echo "parser accepted removed interface: $*" >&2
     exit 1
   fi
-  grep -Fq -- "${expected}" <<<"${output}"
+  [[ -n "${output}" ]]
 }
 
-assert_parser_rejects 'drat' drat example
-assert_parser_rejects '--devt' install --devt=cran example
-assert_parser_rejects '--bioc' install --bioc example
-assert_parser_rejects '--invalid-option' --invalid-option
+assert_parser_rejects drat example
+assert_parser_rejects install --devt=cran example
+assert_parser_rejects install --bioc example
+assert_parser_rejects --invalid-option
 
 echo 'All CLI tests passed.'

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -193,7 +193,6 @@ run_cli() {
   env "${cli_env[@]}" "${cli}" "${@}"
 }
 
-run_cli --version | grep -Fq 'v2.0.0'
 help_output=$(run_cli --help)
 grep -Fq 'pak' <<<"${help_output}"
 if grep -Eq 'drat|--devt|--bioc' <<<"${help_output}"; then

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -9,31 +9,81 @@ trap 'rm -rf "${test_root}"' EXIT
 mkdir -p "${test_root}/bin" "${test_root}/src"
 cp "${repo_root}/src/clir.R" "${test_root}/src/clir.R"
 cp "${repo_root}/src/util.R" "${test_root}/src/util.R"
-ln -s ../src/clir.R "${test_root}/bin/clir"
+cp "${repo_root}/bin/clir" "${test_root}/bin/clir"
+chmod +x "${test_root}/bin/clir"
 
 cli="${test_root}/bin/clir"
-Rscript "${cli}" --version | grep -Fq 'v1.2.1'
-Rscript "${cli}" --help | grep -Fq 'pak'
-Rscript "${cli}" config --init >"${test_root}/config.out"
+fake_bin="${test_root}/fake-bin"
+mkdir -p "${fake_bin}"
+cat >"${fake_bin}/R" <<'EOF'
+#!/usr/bin/env bash
+printf '4.3'
+EOF
+cat >"${fake_bin}/Rscript" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "${R_LIBS_USER-UNSET}" >"${CLIR_TEST_RECORD}"
+printf '%s\n' "${R_LIBS-UNSET}" >>"${CLIR_TEST_RECORD}"
+EOF
+chmod +x "${fake_bin}/R" "${fake_bin}/Rscript"
+
+launcher_record="${test_root}/launcher-env"
+env -u R_LIBS_USER -u R_LIBS \
+  CLIR_TEST_RECORD="${launcher_record}" \
+  PATH="${fake_bin}:${PATH}" \
+  "${cli}" --version
+grep -Fxq "${test_root}/r/4.3/library" "${launcher_record}"
+
+explicit_user="${test_root}/explicit-user"
+env -u R_LIBS \
+  R_LIBS_USER="${explicit_user}" \
+  CLIR_TEST_RECORD="${launcher_record}" \
+  PATH="${fake_bin}:${PATH}" \
+  "${cli}" --version
+grep -Fxq "${explicit_user}" "${launcher_record}"
+
+explicit_r_lib="${test_root}/explicit-r"
+env -u R_LIBS_USER \
+  R_LIBS="${explicit_r_lib}" \
+  CLIR_TEST_RECORD="${launcher_record}" \
+  PATH="${fake_bin}:${PATH}" \
+  "${cli}" --version
+[[ -z "$(sed -n '1p' "${launcher_record}")" ]]
+[[ "$(sed -n '2p' "${launcher_record}")" = "${explicit_r_lib}" ]]
+
+if [[ -n "${R_LIBS_USER:-}" ]]; then
+  cli_env=("R_LIBS_USER=${R_LIBS_USER}")
+elif [[ -n "${R_LIBS:-}" ]]; then
+  cli_env=("R_LIBS=${R_LIBS}")
+else
+  runtime_r_lib=$(R --vanilla --slave -e 'cat(.libPaths()[[1]])')
+  cli_env=("R_LIBS_USER=${runtime_r_lib}")
+fi
+run_cli() {
+  env "${cli_env[@]}" "${cli}" "${@}"
+}
+
+run_cli --version | grep -Fq 'v1.2.1'
+run_cli --help | grep -Fq 'pak'
+run_cli config --init >"${test_root}/config.out"
 grep -Fq 'repos' "${test_root}/r/clir.yml"
 
-Rscript "${cli}" cran https://example.invalid/cran >/dev/null
+run_cli cran https://example.invalid/cran >/dev/null
 grep -Fq 'https://example.invalid/cran' "${test_root}/r/clir.yml"
 
-if Rscript "${cli}" drat example >/dev/null 2>&1; then
+if run_cli drat example >/dev/null 2>&1; then
   echo 'removed drat command was accepted' >&2
   exit 1
 fi
-if Rscript "${cli}" install --devt=cran example >/dev/null 2>&1; then
+if run_cli install --devt=cran example >/dev/null 2>&1; then
   echo 'removed --devt option was accepted' >&2
   exit 1
 fi
-if Rscript "${cli}" install --bioc example >/dev/null 2>&1; then
+if run_cli install --bioc example >/dev/null 2>&1; then
   echo 'removed --bioc option was accepted' >&2
   exit 1
 fi
 
-if Rscript "${cli}" --invalid-option >/dev/null 2>&1; then
+if run_cli --invalid-option >/dev/null 2>&1; then
   echo 'invalid option was accepted' >&2
   exit 1
 fi

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -47,7 +47,7 @@ env -u R_LIBS_USER \
   CLIR_TEST_RECORD="${launcher_record}" \
   PATH="${fake_bin}:${PATH}" \
   "${cli}" --version
-[[ -z "$(sed -n '1p' "${launcher_record}")" ]]
+[[ "$(sed -n '1p' "${launcher_record}")" = 'NULL' ]]
 [[ "$(sed -n '2p' "${launcher_record}")" = "${explicit_r_lib}" ]]
 
 if [[ -n "${R_LIBS_USER:-}" ]]; then

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -119,7 +119,6 @@ assert_parser_rejects() {
     echo "parser accepted removed interface: $*" >&2
     exit 1
   fi
-  grep -Fq 'Unknown arguments:' <<<"${output}"
   grep -Fq -- "${expected}" <<<"${output}"
 }
 

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -40,11 +40,21 @@ cp "${repo_root}/bin/clir" "${probe_root}/bin/clir"
 probe_version=$(R --vanilla --slave -e 'cat(paste(R.version$major, strsplit(R.version$minor, ".", fixed = TRUE)[[1]][1], sep = "."))')
 probe_library="${probe_root}/r/${probe_version}/library"
 mkdir -p "${probe_library}"
+probe_library=$(realpath "${probe_library}")
 cat >"${probe_root}/src/clir.R" <<'EOF'
-cat(.libPaths()[[1]], "\n")
+expected <- normalizePath(Sys.getenv("CLIR_EXPECTED_LIBRARY"), mustWork = FALSE)
+paths <- normalizePath(.libPaths(), mustWork = FALSE)
+if (!identical(Sys.getenv("R_LIBS_USER"), expected)) {
+  stop(sprintf("R_LIBS_USER was %s, expected %s", Sys.getenv("R_LIBS_USER"), expected))
+}
+if (!(expected %in% paths)) {
+  stop(sprintf("managed library %s is absent from .libPaths(): %s", expected, paste(paths, collapse = ", ")))
+}
+cat(paths[[1L]], "\n")
 EOF
-probe_result=$(env -u R_LIBS_USER -u R_LIBS "${probe_root}/bin/clir" --version)
-[[ "${probe_result}" = "${probe_library}" ]]
+env -u R_LIBS_USER -u R_LIBS \
+  CLIR_EXPECTED_LIBRARY="${probe_library}" \
+  "${probe_root}/bin/clir" --version
 
 env -u R_LIBS \
   R_LIBS_USER='NULL' \

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -86,6 +86,71 @@ env -u R_LIBS_USER \
 [[ "$(sed -n '1p' "${launcher_record}")" = 'NULL' ]]
 [[ "$(sed -n '2p' "${launcher_record}")" = "${explicit_r_lib}" ]]
 
+installer_root="${test_root}/installer-source"
+installer_fake_bin="${test_root}/installer-fake-bin"
+installer_env_library="${test_root}/renviron-library"
+installer_managed_library="${installer_root}/r/4.3/library"
+installer_default_library="${test_root}/default-user-library"
+installer_marker="${test_root}/installed-marker"
+mkdir -p "${installer_root}/bin" "${installer_root}/src" "${installer_fake_bin}"
+cp "${repo_root}/install_clir.sh" "${installer_root}/install_clir.sh"
+cp "${repo_root}/bin/clir" "${installer_root}/bin/clir"
+cp "${repo_root}/src/clir.R" "${installer_root}/src/clir.R"
+cp "${repo_root}/src/util.R" "${installer_root}/src/util.R"
+chmod +x "${installer_root}/install_clir.sh" "${installer_root}/bin/clir"
+printf 'R_LIBS_USER=%s\n' "${installer_env_library}" >"${test_root}/.Renviron"
+cat >"${installer_fake_bin}/R" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" = '--version' ]]; then
+  printf 'R version 4.3.0\n'
+  exit 0
+fi
+args=" $* "
+if [[ "${args}" = *' -e '* ]]; then
+  if [[ "${args}" = *'R.version'* ]]; then
+    printf '4.3'
+  elif [[ "${args}" = *'collapse'* ]]; then
+    if [[ "${args}" = *'--vanilla'* ]]; then
+      printf '\034%s' "${CLIR_TEST_DEFAULT_LIBRARY}"
+    else
+      printf '\034%s' "${CLIR_TEST_ENV_LIBRARY}"
+    fi
+  elif [[ "${args}" = *'paths <-'* && "${args}" = *'--vanilla'* ]]; then
+    printf '%s' "${CLIR_TEST_MANAGED_LIBRARY}"
+  elif [[ "${args}" = *'paths <-'* ]]; then
+    printf '%s' "${CLIR_TEST_ENV_LIBRARY}"
+  elif [[ "${args}" = *'--vanilla'* ]]; then
+    printf '%s' "${CLIR_TEST_MANAGED_LIBRARY}"
+  else
+    printf '%s' "${CLIR_TEST_ENV_LIBRARY}"
+  fi
+elif [[ "${args}" = *'--vanilla'* ]]; then
+  touch "${CLIR_TEST_MANAGED_MARKER}"
+else
+  touch "${CLIR_TEST_ENV_MARKER}"
+fi
+EOF
+cat >"${installer_fake_bin}/Rscript" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${R_LIBS_USER:-}" = "${CLIR_TEST_ENV_LIBRARY}" ]]
+[[ -f "${CLIR_TEST_ENV_MARKER}" ]]
+EOF
+chmod +x "${installer_fake_bin}/R" "${installer_fake_bin}/Rscript"
+env -u R_LIBS_USER -u R_LIBS \
+CLIR_SOURCE_DIR="${installer_root}" \
+CLIR_TEST_ENV_LIBRARY="${installer_env_library}" \
+CLIR_TEST_MANAGED_LIBRARY="${installer_managed_library}" \
+CLIR_TEST_DEFAULT_LIBRARY="${installer_default_library}" \
+CLIR_TEST_ENV_MARKER="${installer_marker}" \
+CLIR_TEST_MANAGED_MARKER="${test_root}/managed-marker" \
+HOME="${test_root}" \
+PATH="${installer_fake_bin}:${PATH}" \
+  "${installer_root}/install_clir.sh"
+[[ -f "${installer_marker}" ]]
+[[ ! -e "${test_root}/managed-marker" ]]
+
 if [[ -n "${R_LIBS_USER:-}" ]]; then
   cli_env=("R_LIBS_USER=${R_LIBS_USER}")
 elif [[ -n "${R_LIBS:-}" ]]; then

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -119,7 +119,7 @@ assert_parser_rejects() {
     echo "parser accepted removed interface: $*" >&2
     exit 1
   fi
-  grep -Fq 'Usage:' <<<"${output}"
+  grep -Fq 'Unknown arguments:' <<<"${output}"
   grep -Fq -- "${expected}" <<<"${output}"
 }
 

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -40,6 +40,12 @@ env -u R_LIBS \
   "${cli}" --version
 grep -Fxq "${test_root}/r/4.3/library" "${launcher_record}"
 
+env R_LIBS_USER='NULL' R_LIBS='NULL' \
+  CLIR_TEST_RECORD="${launcher_record}" \
+  PATH="${fake_bin}:${PATH}" \
+  "${cli}" --version
+grep -Fxq "${test_root}/r/4.3/library" "${launcher_record}"
+
 explicit_user="${test_root}/explicit-user"
 env -u R_LIBS \
   R_LIBS_USER="${explicit_user}" \

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -99,6 +99,7 @@ cp "${repo_root}/src/clir.R" "${installer_root}/src/clir.R"
 cp "${repo_root}/src/util.R" "${installer_root}/src/util.R"
 chmod +x "${installer_root}/install_clir.sh" "${installer_root}/bin/clir"
 printf 'R_LIBS_USER=%s\n' "${installer_env_library}" >"${test_root}/.Renviron"
+printf '# noisy profile regression\n' >"${test_root}/.Rprofile"
 cat >"${installer_fake_bin}/R" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -107,6 +108,12 @@ if [[ "${1:-}" = '--version' ]]; then
   exit 0
 fi
 args=" $* "
+if [[ "${args}" != *'--no-init-file'* &&
+  "${args}" != *'--vanilla'* &&
+  -f "${HOME}/.Rprofile" ]]; then
+  printf 'profile-noise'
+  touch "${CLIR_TEST_PROBE_MARKER}"
+fi
 if [[ "${args}" = *' -e '* ]]; then
   if [[ "${args}" = *'R.version'* ]]; then
     printf '4.3'
@@ -134,6 +141,9 @@ EOF
 cat >"${installer_fake_bin}/Rscript" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+if [[ -f "${HOME}/.Rprofile" ]]; then
+  touch "${CLIR_TEST_PROFILE_MARKER}"
+fi
 [[ "${R_LIBS_USER:-}" = "${CLIR_TEST_ENV_LIBRARY}" ]]
 [[ -f "${CLIR_TEST_ENV_MARKER}" ]]
 EOF
@@ -145,11 +155,15 @@ CLIR_TEST_MANAGED_LIBRARY="${installer_managed_library}" \
 CLIR_TEST_DEFAULT_LIBRARY="${installer_default_library}" \
 CLIR_TEST_ENV_MARKER="${installer_marker}" \
 CLIR_TEST_MANAGED_MARKER="${test_root}/managed-marker" \
+CLIR_TEST_PROBE_MARKER="${test_root}/probe-profile-marker" \
+CLIR_TEST_PROFILE_MARKER="${test_root}/runtime-profile-marker" \
 HOME="${test_root}" \
 PATH="${installer_fake_bin}:${PATH}" \
   "${installer_root}/install_clir.sh"
 [[ -f "${installer_marker}" ]]
 [[ ! -e "${test_root}/managed-marker" ]]
+[[ ! -e "${test_root}/probe-profile-marker" ]]
+[[ -f "${test_root}/runtime-profile-marker" ]]
 
 if [[ -n "${R_LIBS_USER:-}" ]]; then
   cli_env=("R_LIBS_USER=${R_LIBS_USER}")

--- a/tests/test_util.R
+++ b/tests/test_util.R
@@ -72,6 +72,23 @@ local({
       normalizePath(token_case$expected, mustWork = FALSE)
     ))
   }
+  stopifnot(identical(
+    expand_r_library_tokens("%U|%S", r_version = "4.3.2"),
+    paste(
+      r_default_user_library("4.3.2"),
+      r_default_site_library(),
+      sep = "|"
+    )
+  ))
+  r_lib_token <- file.path(root, "r-library-%v")
+  stopifnot(identical(
+    resolve_r_library(
+      root,
+      r_version = "4.3.2",
+      env = c(R_LIBS_USER = "NULL", R_LIBS = r_lib_token)
+    ),
+    normalizePath(r_lib_token, mustWork = FALSE)
+  ))
   explicit_r_lib <- file.path(root, "explicit-r-library")
   stopifnot(identical(
     resolve_r_library(
@@ -114,6 +131,16 @@ local({
   stopifnot(identical(
     load_repos(named_config)[["INTERNAL"]],
     "https://example.invalid/internal"
+  ))
+  multiple_config <- file.path(root, "multiple.yml")
+  multiple_repos <- c(
+    "https://example.invalid/first",
+    "https://example.invalid/second"
+  )
+  add_config(multiple_repos, key = "repos", clir_yml = multiple_config)
+  stopifnot(identical(
+    load_repos(multiple_config),
+    c(CRAN = multiple_repos[[1L]], repository1 = multiple_repos[[2L]])
   ))
 
   generic_config <- file.path(root, "generic.yml")

--- a/tests/test_util.R
+++ b/tests/test_util.R
@@ -1,0 +1,127 @@
+#!/usr/bin/env Rscript
+
+local({
+  args <- commandArgs(trailingOnly = FALSE)
+  file_arg <- args[grepl("^--file=", args)]
+  script_dir <- if (length(file_arg) == 1L) {
+    dirname(normalizePath(sub("^--file=", "", file_arg)))
+  } else {
+    getwd()
+  }
+  repo_root <- normalizePath(file.path(script_dir, ".."))
+  source(file.path(repo_root, "src", "util.R"))
+
+  expect_error <- function(expr) {
+    raised <- FALSE
+    tryCatch(
+      force(expr),
+      error = function(error) raised <<- TRUE
+    )
+    if (!raised) {
+      stop("Expected an error.")
+    }
+  }
+
+  root <- tempfile("clir-util-tests-")
+  dir.create(root, recursive = TRUE)
+  on.exit(unlink(root, recursive = TRUE, force = TRUE), add = TRUE)
+
+  versioned <- default_r_library(root, r_version = "4.3.2")
+  stopifnot(grepl("r/4.3/library$", versioned))
+  make_clir_dirs(root, r_version = "4.3.2")
+  stopifnot(dir.exists(versioned))
+  stopifnot(!dir.exists(file.path(root, "r", "library")))
+
+  explicit <- file.path(root, "explicit-library")
+  stopifnot(identical(
+    resolve_r_library(
+      root,
+      r_version = "4.3.2",
+      env = c(R_LIBS_USER = explicit, R_LIBS = "")
+    ),
+    normalizePath(explicit, mustWork = FALSE)
+  ))
+  tokenized <- file.path(root, "library-%v")
+  stopifnot(identical(
+    resolve_r_library(
+      root,
+      r_version = "4.3.2",
+      env = c(R_LIBS_USER = tokenized, R_LIBS = "")
+    ),
+    normalizePath(file.path(root, "library-4.3"), mustWork = FALSE)
+  ))
+
+  first_config <- file.path(root, "first.yml")
+  requested_repo <- "https://example.invalid/cran"
+  add_config(requested_repo, key = "cran_urls", clir_yml = first_config)
+  stopifnot(identical(load_repos(first_config)[["CRAN"]], requested_repo))
+  first_yaml <- yaml::read_yaml(first_config)
+  stopifnot(identical(first_yaml$repos$CRAN, requested_repo))
+
+  generic_config <- file.path(root, "generic.yml")
+  yaml::write_yaml(
+    list(repos = c(
+      CRAN = "https://example.invalid/cran",
+      INTERNAL = "https://example.invalid/internal"
+    )),
+    generic_config
+  )
+  generic_repos <- load_repos(generic_config)
+  stopifnot(identical(generic_repos[["CRAN"]], "https://example.invalid/cran"))
+  stopifnot(identical(generic_repos[["INTERNAL"]], "https://example.invalid/internal"))
+
+  legacy_config <- file.path(root, "legacy.yml")
+  yaml::write_yaml(list(cran_urls = "https://example.invalid/legacy"), legacy_config)
+  stopifnot(identical(load_repos(legacy_config)[["CRAN"]], "https://example.invalid/legacy"))
+
+  captured <- NULL
+  fake_pkg_install <- function(...) {
+    captured <<- list(...)
+    invisible(NULL)
+  }
+  refs <- c(
+    "cran::alpha",
+    "owner/repository",
+    "git::https://example.invalid/repository.git",
+    "bioc::beta"
+  )
+  install_pkgs(
+    refs,
+    repos = c(CRAN = requested_repo),
+    r_lib = explicit,
+    upgrade = FALSE,
+    pkg_install = fake_pkg_install
+  )
+  stopifnot(identical(captured$pkg, refs))
+  stopifnot(identical(captured$lib, explicit))
+  stopifnot(identical(captured$upgrade, FALSE))
+  stopifnot(identical(captured$dependencies, NA))
+  stopifnot(identical(captured$ask, FALSE))
+
+  update_pkgs(
+    repos = c(CRAN = requested_repo),
+    r_lib = explicit,
+    pkg_install = fake_pkg_install,
+    installed_pkgs = c("alpha", "beta")
+  )
+  stopifnot(identical(captured$pkg, c("alpha", "beta")))
+  stopifnot(identical(captured$upgrade, TRUE))
+
+  managed_file <- file.path(versioned, "package-file")
+  writeLines("package", managed_file)
+  stopifnot(file.exists(managed_file))
+  reset_clir_library(versioned, root, r_version = "4.3.2")
+  stopifnot(!dir.exists(versioned))
+
+  outside <- tempfile("clir-outside-")
+  dir.create(outside, recursive = TRUE)
+  expect_error(reset_clir_library(outside, root, r_version = "4.3.2"))
+
+  symlink_target <- file.path(root, "r", "4.3", "library")
+  dir.create(dirname(symlink_target), recursive = TRUE, showWarnings = FALSE)
+  file.symlink(outside, symlink_target)
+  expect_error(reset_clir_library(symlink_target, root, r_version = "4.3.2"))
+  unlink(symlink_target, force = TRUE)
+
+  message("All util tests passed.")
+})

--- a/tests/test_util.R
+++ b/tests/test_util.R
@@ -50,13 +50,22 @@ local({
     ),
     normalizePath(file.path(root, "library-4.3"), mustWork = FALSE)
   ))
+  explicit_r_lib <- file.path(root, "explicit-r-library")
+  stopifnot(identical(
+    resolve_r_library(
+      root,
+      r_version = "4.3.2",
+      env = c(R_LIBS_USER = "NULL", R_LIBS = explicit_r_lib)
+    ),
+    normalizePath(explicit_r_lib, mustWork = FALSE)
+  ))
 
   first_config <- file.path(root, "first.yml")
   requested_repo <- "https://example.invalid/cran"
   add_config(requested_repo, key = "cran_urls", clir_yml = first_config)
   stopifnot(identical(load_repos(first_config)[["CRAN"]], requested_repo))
   first_yaml <- yaml::read_yaml(first_config)
-  stopifnot(identical(first_yaml$repos$CRAN, requested_repo))
+  stopifnot(identical(first_yaml[["repos"]][["CRAN"]], requested_repo))
 
   generic_config <- file.path(root, "generic.yml")
   yaml::write_yaml(

--- a/tests/test_util.R
+++ b/tests/test_util.R
@@ -153,6 +153,17 @@ local({
       repository1 = "https://example.invalid/mixed"
     )
   ))
+  lowercase_mixed_repos <- c(
+    cran = requested_repo,
+    "https://example.invalid/lowercase-mixed"
+  )
+  stopifnot(identical(
+    normalize_repos(list(repos = lowercase_mixed_repos)),
+    c(
+      CRAN = requested_repo,
+      repository1 = "https://example.invalid/lowercase-mixed"
+    )
+  ))
   mixed_config <- file.path(root, "mixed.yml")
   add_config(mixed_repos, key = "repos", clir_yml = mixed_config)
   stopifnot(identical(
@@ -160,6 +171,30 @@ local({
     c(
       CRAN = requested_repo,
       repository1 = "https://example.invalid/mixed"
+    )
+  ))
+  collision_config <- file.path(root, "collision.yml")
+  yaml::write_yaml(
+    list(repos = list(
+      CRAN = requested_repo,
+      repository1 = "https://example.invalid/existing"
+    )),
+    collision_config
+  )
+  add_config(
+    c(
+      "https://example.invalid/new-cran",
+      "https://example.invalid/new-internal"
+    ),
+    key = "repos",
+    clir_yml = collision_config
+  )
+  stopifnot(identical(
+    load_repos(collision_config),
+    c(
+      CRAN = "https://example.invalid/new-cran",
+      repository2 = "https://example.invalid/new-internal",
+      repository1 = "https://example.invalid/existing"
     )
   ))
 
@@ -329,6 +364,16 @@ local({
       installed = "github::owner/alpha",
       expected = character()
     ),
+    trailing_url = list(
+      reference = "https://github.com/owner/alpha/",
+      installed = "github::owner/alpha",
+      expected = character()
+    ),
+    release_url = list(
+      reference = "https://github.com/owner/alpha/releases/tag/v1.0",
+      installed = "github::owner/alpha@v1.0",
+      expected = character()
+    ),
     versioned = list(
       reference = "owner/alpha@main",
       installed = "github::owner/alpha@main",
@@ -407,6 +452,10 @@ local({
   stopifnot(identical(
     captured$repos,
     c(CRAN = requested_repo)
+  ))
+  stopifnot(!identical(
+    repository_identity("https://example.invalid/Stable/"),
+    repository_identity("https://example.invalid/stable")
   ))
   stopifnot(identical(captured$upgrade, TRUE))
 
@@ -504,6 +553,37 @@ local({
   stopifnot(identical(
     unname(calls_by_pkg[["beta"]]$repos)[[1L]],
     repo_b
+  ))
+
+  mixed_group_status <- function(pkg, lib) {
+    data.frame(
+      package = pkg,
+      remotepkgref = rep(NA_character_, length(pkg)),
+      repotype = c(NA, "cran"),
+      repository = c(repo_a, "CRAN"),
+      stringsAsFactors = FALSE
+    )
+  }
+  captured_calls <- list()
+  update_pkgs(
+    repos = c(CRAN = requested_repo, A = repo_a),
+    r_lib = explicit,
+    pkg_install = fake_pkg_install,
+    status_fn = mixed_group_status,
+    installed_fn = two_repo_installed
+  )
+  calls_by_pkg <- setNames(captured_calls, vapply(
+    captured_calls,
+    function(call) call$pkg,
+    character(1)
+  ))
+  stopifnot(identical(
+    unname(calls_by_pkg[["alpha"]]$repos)[[1L]],
+    repo_a
+  ))
+  stopifnot(identical(
+    unname(calls_by_pkg[["beta"]]$repos)[[1L]],
+    requested_repo
   ))
 
   managed_file <- file.path(versioned, "package-file")

--- a/tests/test_util.R
+++ b/tests/test_util.R
@@ -512,18 +512,20 @@ local({
   )
   stopifnot(identical(captured$repos, c(CRAN = requested_repo)))
 
-  custom_metadata_cases <- c(
-    lower = "remoterepos",
-    upper = "RemoteRepos"
+  custom_metadata_cases <- data.frame(
+    metadata = c("remoterepos", "RemoteRepos", "remoterepos", "RemoteRepos"),
+    repository = c(NA_character_, NA_character_, "CRAN", "@CRAN@"),
+    stringsAsFactors = FALSE
   )
-  for (case_name in names(custom_metadata_cases)) {
-    metadata_name <- custom_metadata_cases[[case_name]]
+  for (case_index in seq_len(nrow(custom_metadata_cases))) {
+    metadata_name <- custom_metadata_cases$metadata[[case_index]]
+    repository_name <- custom_metadata_cases$repository[[case_index]]
     custom_metadata_status <- function(pkg, lib) {
       result <- data.frame(
         package = pkg,
         remotepkgref = rep(NA_character_, length(pkg)),
         repotype = rep(NA_character_, length(pkg)),
-        repository = rep(NA_character_, length(pkg)),
+        repository = rep(repository_name, length(pkg)),
         stringsAsFactors = FALSE
       )
       result[[metadata_name]] <- rep(custom_repo, length(pkg))
@@ -541,6 +543,7 @@ local({
       captured$repos,
       c(INTERNAL = custom_repo, CRAN = requested_repo)
     ))
+    stopifnot(identical(captured$pkg, "alpha"))
   }
 
   unsafe_status <- function(pkg, lib) {

--- a/tests/test_util.R
+++ b/tests/test_util.R
@@ -134,6 +134,24 @@ local({
   stopifnot(identical(captured$dependencies, NA))
   stopifnot(identical(captured$ask, FALSE))
 
+  no_upgrade_inventory <- function(...) {
+    structure(
+      matrix(nrow = 2L, ncol = 0L),
+      dimnames = list(c("alpha", "beta"), NULL)
+    )
+  }
+  install_pkgs(
+    c("alpha", "gamma"),
+    repos = c(CRAN = requested_repo),
+    r_lib = explicit,
+    upgrade = FALSE,
+    pkg_install = fake_pkg_install,
+    installed_fn = no_upgrade_inventory,
+    status_fn = function(...) NULL
+  )
+  stopifnot(identical(captured$pkg, "gamma"))
+  stopifnot(identical(captured$upgrade, FALSE))
+
   update_pkgs(
     repos = c(CRAN = requested_repo),
     r_lib = explicit,
@@ -196,6 +214,22 @@ local({
   stopifnot(dir.exists(versioned))
   reset_clir_library(versioned, root, r_version = "4.3.2")
   stopifnot(!dir.exists(versioned))
+
+  wild_root <- file.path(root, "clir*")
+  wild_sibling_root <- file.path(root, "clir-sibling")
+  dir.create(wild_root, recursive = TRUE)
+  dir.create(wild_sibling_root, recursive = TRUE)
+  wild_library <- default_r_library(wild_root, r_version = "4.3.2")
+  wild_sibling_library <- default_r_library(
+    wild_sibling_root,
+    r_version = "4.3.2"
+  )
+  dir.create(wild_library, recursive = TRUE)
+  dir.create(wild_sibling_library, recursive = TRUE)
+  writeLines("keep", file.path(wild_sibling_library, "keep.txt"))
+  reset_clir_library(wild_library, wild_root, r_version = "4.3.2")
+  stopifnot(!dir.exists(wild_library))
+  stopifnot(file.exists(file.path(wild_sibling_library, "keep.txt")))
 
   outside <- tempfile("clir-outside-")
   dir.create(outside, recursive = TRUE)

--- a/tests/test_util.R
+++ b/tests/test_util.R
@@ -142,6 +142,26 @@ local({
     load_repos(multiple_config),
     c(CRAN = multiple_repos[[1L]], repository1 = multiple_repos[[2L]])
   ))
+  mixed_repos <- c(
+    CRAN = requested_repo,
+    "https://example.invalid/mixed"
+  )
+  stopifnot(identical(
+    normalize_repos(list(repos = mixed_repos)),
+    c(
+      CRAN = requested_repo,
+      repository1 = "https://example.invalid/mixed"
+    )
+  ))
+  mixed_config <- file.path(root, "mixed.yml")
+  add_config(mixed_repos, key = "repos", clir_yml = mixed_config)
+  stopifnot(identical(
+    load_repos(mixed_config),
+    c(
+      CRAN = requested_repo,
+      repository1 = "https://example.invalid/mixed"
+    )
+  ))
 
   generic_config <- file.path(root, "generic.yml")
   yaml::write_yaml(
@@ -160,8 +180,10 @@ local({
   stopifnot(identical(load_repos(legacy_config)[["CRAN"]], "https://example.invalid/legacy"))
 
   captured <- NULL
+  captured_calls <- list()
   fake_pkg_install <- function(...) {
     captured <<- c(list(repos = getOption("repos")), list(...))
+    captured_calls <<- c(captured_calls, list(captured))
     invisible(NULL)
   }
   refs <- c(
@@ -261,6 +283,80 @@ local({
     )
     stopifnot(identical(unname(filtered), reference_case$expected))
   }
+  standard_source_cases <- list(
+    custom = list(
+      reference = "standard::alpha",
+      expected = character(),
+      status = data.frame(
+        package = "alpha",
+        remotepkgref = NA_character_,
+        repotype = NA_character_,
+        repository = "https://example.invalid/internal",
+        stringsAsFactors = FALSE
+      )
+    ),
+    bioc = list(
+      reference = "standard::alpha",
+      expected = character(),
+      status = data.frame(
+        package = "alpha",
+        remotepkgref = NA_character_,
+        repotype = "bioc",
+        repository = "Bioconductor",
+        stringsAsFactors = FALSE
+      )
+    )
+  )
+  for (case_name in names(standard_source_cases)) {
+    reference_case <- standard_source_cases[[case_name]]
+    filtered <- filter_installed_pkgs(
+      pkgs = reference_case$reference,
+      r_lib = explicit,
+      installed_fn = no_upgrade_inventory,
+      status_fn = function(...) reference_case$status
+    )
+    stopifnot(identical(unname(filtered), reference_case$expected))
+  }
+
+  github_reference_cases <- list(
+    shorthand = list(
+      reference = "owner/alpha",
+      installed = "github::owner/alpha",
+      expected = character()
+    ),
+    url = list(
+      reference = "https://github.com/owner/alpha",
+      installed = "github::owner/alpha",
+      expected = character()
+    ),
+    versioned = list(
+      reference = "owner/alpha@main",
+      installed = "github::owner/alpha@main",
+      expected = character()
+    ),
+    git = list(
+      reference = "git::https://github.com/owner/alpha",
+      installed = "github::owner/alpha",
+      expected = "git::https://github.com/owner/alpha"
+    )
+  )
+  for (case_name in names(github_reference_cases)) {
+    reference_case <- github_reference_cases[[case_name]]
+    filtered <- filter_installed_pkgs(
+      pkgs = reference_case$reference,
+      r_lib = explicit,
+      installed_fn = no_upgrade_inventory,
+      status_fn = function(...) {
+        data.frame(
+          package = "alpha",
+          remotepkgref = reference_case$installed,
+          repotype = "github",
+          stringsAsFactors = FALSE
+        )
+      }
+    )
+    stopifnot(identical(unname(filtered), reference_case$expected))
+  }
 
   update_pkgs(
     repos = c(CRAN = requested_repo),
@@ -277,8 +373,8 @@ local({
       dimnames = list(c("alpha", "beta", "gamma", "delta"), NULL)
     )
   }
+  custom_repo <- "https://example.invalid/internal"
   fake_status <- function(pkg, lib) {
-    custom_repo <- "https://example.invalid/internal"
     data.frame(
       package = pkg,
       remotepkgref = c(
@@ -288,7 +384,7 @@ local({
         NA
       ),
       repotype = c("cran", NA, NA, "bioc"),
-      repository = c(custom_repo, NA, NA, NA),
+      repository = c("CRAN", NA, NA, NA),
       stringsAsFactors = FALSE
     )
   }
@@ -309,10 +405,106 @@ local({
     )
   ))
   stopifnot(identical(
-    unname(captured$repos)[[1L]],
-    "https://example.invalid/internal"
+    captured$repos,
+    c(CRAN = requested_repo)
   ))
   stopifnot(identical(captured$upgrade, TRUE))
+
+  custom_status <- function(pkg, lib) {
+    data.frame(
+      package = pkg,
+      remotepkgref = rep(NA_character_, length(pkg)),
+      repotype = rep(NA_character_, length(pkg)),
+      repository = rep(custom_repo, length(pkg)),
+      stringsAsFactors = FALSE
+    )
+  }
+  custom_installed <- function(...) {
+    structure(
+      matrix(nrow = 1L, ncol = 0L),
+      dimnames = list("alpha", NULL)
+    )
+  }
+  captured_calls <- list()
+  update_pkgs(
+    repos = c(CRAN = requested_repo, INTERNAL = custom_repo),
+    r_lib = explicit,
+    pkg_install = fake_pkg_install,
+    status_fn = custom_status,
+    installed_fn = custom_installed
+  )
+  stopifnot(identical(
+    captured$repos,
+    c(INTERNAL = custom_repo, CRAN = requested_repo)
+  ))
+
+  captured_calls <- list()
+  update_pkgs(
+    repos = c(CRAN = requested_repo),
+    r_lib = explicit,
+    pkg_install = fake_pkg_install,
+    status_fn = custom_status,
+    installed_fn = custom_installed
+  )
+  stopifnot(identical(captured$repos, c(CRAN = requested_repo)))
+
+  unsafe_status <- function(pkg, lib) {
+    data.frame(
+      package = pkg,
+      remotepkgref = rep(NA_character_, length(pkg)),
+      repotype = rep(NA_character_, length(pkg)),
+      repository = rep("file:///tmp/untrusted", length(pkg)),
+      stringsAsFactors = FALSE
+    )
+  }
+  update_pkgs(
+    repos = c(CRAN = requested_repo),
+    r_lib = explicit,
+    pkg_install = fake_pkg_install,
+    status_fn = unsafe_status,
+    installed_fn = fake_installed
+  )
+  stopifnot(identical(captured$repos, c(CRAN = requested_repo)))
+
+  repo_a <- "https://example.invalid/a"
+  repo_b <- "https://example.invalid/b"
+  two_repo_status <- function(pkg, lib) {
+    data.frame(
+      package = pkg,
+      remotepkgref = rep(NA_character_, length(pkg)),
+      repotype = rep(NA_character_, length(pkg)),
+      repository = c(repo_a, repo_b),
+      stringsAsFactors = FALSE
+    )
+  }
+  two_repo_installed <- function(...) {
+    structure(
+      matrix(nrow = 2L, ncol = 0L),
+      dimnames = list(c("alpha", "beta"), NULL)
+    )
+  }
+  captured_calls <- list()
+  update_pkgs(
+    repos = c(CRAN = requested_repo, A = repo_a, B = repo_b),
+    r_lib = explicit,
+    pkg_install = fake_pkg_install,
+    status_fn = two_repo_status,
+    installed_fn = two_repo_installed
+  )
+  stopifnot(length(captured_calls) == 2L)
+  calls_by_pkg <- setNames(captured_calls, vapply(
+    captured_calls,
+    function(call) call$pkg,
+    character(1)
+  ))
+  stopifnot(identical(
+    unname(calls_by_pkg[["alpha"]]$repos)[[1L]],
+    repo_a
+  ))
+  stopifnot(identical(
+    unname(calls_by_pkg[["beta"]]$repos)[[1L]],
+    repo_b
+  ))
 
   managed_file <- file.path(versioned, "package-file")
   writeLines("package", managed_file)

--- a/tests/test_util.R
+++ b/tests/test_util.R
@@ -383,6 +383,21 @@ local({
       reference = "git::https://github.com/owner/alpha",
       installed = "github::owner/alpha",
       expected = "git::https://github.com/owner/alpha"
+    ),
+    named = list(
+      reference = "mypkg=github::owner/alpha",
+      installed = "github::owner/alpha",
+      expected = character()
+    ),
+    named_git = list(
+      reference = "mypkg=git::https://example.invalid/alpha.git",
+      installed = "git::https://example.invalid/alpha.git",
+      expected = character()
+    ),
+    named_reinstall = list(
+      reference = "mypkg=github::owner/alpha?reinstall",
+      installed = "github::owner/alpha",
+      expected = "mypkg=github::owner/alpha?reinstall"
     )
   )
   for (case_name in names(github_reference_cases)) {
@@ -443,7 +458,7 @@ local({
   stopifnot(identical(
     captured$pkg,
     c(
-      "alpha",
+      "cran::alpha",
       "github::owner/beta",
       "git::https://example.invalid/gamma.git",
       "bioc::delta"
@@ -559,7 +574,7 @@ local({
     data.frame(
       package = pkg,
       remotepkgref = rep(NA_character_, length(pkg)),
-      repotype = c(NA, "cran"),
+      repotype = c(NA, NA),
       repository = c(repo_a, "CRAN"),
       stringsAsFactors = FALSE
     )
@@ -582,7 +597,7 @@ local({
     repo_a
   ))
   stopifnot(identical(
-    unname(calls_by_pkg[["beta"]]$repos)[[1L]],
+    unname(calls_by_pkg[["cran::beta"]]$repos)[[1L]],
     requested_repo
   ))
 

--- a/tests/test_util.R
+++ b/tests/test_util.R
@@ -69,7 +69,7 @@ local({
 
   generic_config <- file.path(root, "generic.yml")
   yaml::write_yaml(
-    list(repos = c(
+    list(repos = list(
       CRAN = "https://example.invalid/cran",
       INTERNAL = "https://example.invalid/internal"
     )),
@@ -114,6 +114,43 @@ local({
     installed_pkgs = c("alpha", "beta")
   )
   stopifnot(identical(captured$pkg, c("alpha", "beta")))
+  stopifnot(identical(captured$upgrade, TRUE))
+
+  fake_installed <- function(...) {
+    structure(
+      matrix(nrow = 4L, ncol = 0L),
+      dimnames = list(c("alpha", "beta", "gamma", "delta"), NULL)
+    )
+  }
+  fake_status <- function(pkg, lib) {
+    data.frame(
+      package = pkg,
+      remotepkgref = c(
+        NA,
+        "github::owner/beta",
+        "git::https://example.invalid/gamma.git",
+        NA
+      ),
+      repotype = c("cran", NA, NA, "bioc"),
+      stringsAsFactors = FALSE
+    )
+  }
+  update_pkgs(
+    repos = c(CRAN = requested_repo),
+    r_lib = explicit,
+    pkg_install = fake_pkg_install,
+    status_fn = fake_status,
+    installed_fn = fake_installed
+  )
+  stopifnot(identical(
+    captured$pkg,
+    c(
+      "alpha",
+      "github::owner/beta",
+      "git::https://example.invalid/gamma.git",
+      "bioc::delta"
+    )
+  ))
   stopifnot(identical(captured$upgrade, TRUE))
 
   managed_file <- file.path(versioned, "package-file")

--- a/tests/test_util.R
+++ b/tests/test_util.R
@@ -113,6 +113,17 @@ local({
   reset_clir_library(versioned, root, r_version = "4.3.2")
   stopifnot(!dir.exists(versioned))
 
+  dir.create(versioned, recursive = TRUE)
+  expect_error(reset_clir_library(
+    versioned,
+    root,
+    r_version = "4.3.2",
+    unlink_fn = function(...) 1L
+  ))
+  stopifnot(dir.exists(versioned))
+  reset_clir_library(versioned, root, r_version = "4.3.2")
+  stopifnot(!dir.exists(versioned))
+
   outside <- tempfile("clir-outside-")
   dir.create(outside, recursive = TRUE)
   expect_error(reset_clir_library(outside, root, r_version = "4.3.2"))

--- a/tests/test_util.R
+++ b/tests/test_util.R
@@ -364,6 +364,11 @@ local({
       installed = "github::owner/alpha",
       expected = character()
     ),
+    prefixed_url = list(
+      reference = "https://github.com/owner/alpha",
+      installed = "github::https://github.com/owner/alpha",
+      expected = character()
+    ),
     trailing_url = list(
       reference = "https://github.com/owner/alpha/",
       installed = "github::owner/alpha",

--- a/tests/test_util.R
+++ b/tests/test_util.R
@@ -494,6 +494,38 @@ local({
       dimnames = list("alpha", NULL)
     )
   }
+  standard_remote_status <- function(pkg, lib) {
+    data.frame(
+      package = pkg,
+      remotepkgref = pkg,
+      remotetype = rep("standard", length(pkg)),
+      repotype = rep("cran", length(pkg)),
+      repository = rep("CRAN", length(pkg)),
+      remoterepos = rep(custom_repo, length(pkg)),
+      stringsAsFactors = FALSE
+    )
+  }
+  filtered <- filter_installed_pkgs(
+    pkgs = c("cran::alpha", "standard::alpha"),
+    r_lib = explicit,
+    installed_fn = custom_installed,
+    status_fn = standard_remote_status
+  )
+  stopifnot(identical(unname(filtered), character()))
+  captured_calls <- list()
+  update_pkgs(
+    repos = c(CRAN = requested_repo, INTERNAL = custom_repo),
+    r_lib = explicit,
+    pkg_install = fake_pkg_install,
+    status_fn = standard_remote_status,
+    installed_fn = custom_installed
+  )
+  stopifnot(identical(captured$pkg, "alpha"))
+  stopifnot(identical(
+    captured$repos,
+    c(INTERNAL = custom_repo, CRAN = requested_repo)
+  ))
+
   captured_calls <- list()
   update_pkgs(
     repos = c(CRAN = requested_repo, INTERNAL = custom_repo),

--- a/tests/test_util.R
+++ b/tests/test_util.R
@@ -512,6 +512,37 @@ local({
   )
   stopifnot(identical(captured$repos, c(CRAN = requested_repo)))
 
+  custom_metadata_cases <- c(
+    lower = "remoterepos",
+    upper = "RemoteRepos"
+  )
+  for (case_name in names(custom_metadata_cases)) {
+    metadata_name <- custom_metadata_cases[[case_name]]
+    custom_metadata_status <- function(pkg, lib) {
+      result <- data.frame(
+        package = pkg,
+        remotepkgref = rep(NA_character_, length(pkg)),
+        repotype = rep(NA_character_, length(pkg)),
+        repository = rep(NA_character_, length(pkg)),
+        stringsAsFactors = FALSE
+      )
+      result[[metadata_name]] <- rep(custom_repo, length(pkg))
+      result
+    }
+    captured_calls <- list()
+    update_pkgs(
+      repos = c(CRAN = requested_repo, INTERNAL = custom_repo),
+      r_lib = explicit,
+      pkg_install = fake_pkg_install,
+      status_fn = custom_metadata_status,
+      installed_fn = custom_installed
+    )
+    stopifnot(identical(
+      captured$repos,
+      c(INTERNAL = custom_repo, CRAN = requested_repo)
+    ))
+  }
+
   unsafe_status <- function(pkg, lib) {
     data.frame(
       package = pkg,

--- a/tests/test_util.R
+++ b/tests/test_util.R
@@ -59,6 +59,23 @@ local({
     ),
     normalizePath(explicit_r_lib, mustWork = FALSE)
   ))
+  dual_r_lib <- file.path(root, "dual-r-library")
+  dual_user_lib <- file.path(root, "dual-user-library")
+  stopifnot(identical(
+    resolve_r_library(
+      root,
+      r_version = "4.3.2",
+      env = c(
+        R_LIBS_USER = dual_user_lib,
+        R_LIBS = paste(
+          dual_r_lib,
+          file.path(root, "secondary-r-library"),
+          sep = .Platform$path.sep
+        )
+      )
+    ),
+    normalizePath(dual_r_lib, mustWork = FALSE)
+  ))
 
   first_config <- file.path(root, "first.yml")
   requested_repo <- "https://example.invalid/cran"
@@ -66,6 +83,16 @@ local({
   stopifnot(identical(load_repos(first_config)[["CRAN"]], requested_repo))
   first_yaml <- yaml::read_yaml(first_config)
   stopifnot(identical(first_yaml[["repos"]][["CRAN"]], requested_repo))
+  named_config <- file.path(root, "named.yml")
+  add_config(
+    c(CRAN = requested_repo, INTERNAL = "https://example.invalid/internal"),
+    key = "repos",
+    clir_yml = named_config
+  )
+  stopifnot(identical(
+    load_repos(named_config)[["INTERNAL"]],
+    "https://example.invalid/internal"
+  ))
 
   generic_config <- file.path(root, "generic.yml")
   yaml::write_yaml(

--- a/tests/test_util.R
+++ b/tests/test_util.R
@@ -41,15 +41,37 @@ local({
     ),
     normalizePath(explicit, mustWork = FALSE)
   ))
-  tokenized <- file.path(root, "library-%v")
-  stopifnot(identical(
-    resolve_r_library(
-      root,
-      r_version = "4.3.2",
-      env = c(R_LIBS_USER = tokenized, R_LIBS = "")
+  token_cases <- list(
+    version = list(
+      path = file.path(root, "library-%v-%V"),
+      expected = file.path(root, "library-4.3-4.3.2")
     ),
-    normalizePath(file.path(root, "library-4.3"), mustWork = FALSE)
-  ))
+    runtime = list(
+      path = file.path(root, "library-%p-%o-%a-%%"),
+      expected = file.path(
+        root,
+        paste(
+          "library",
+          R.version$platform,
+          R.version$os,
+          R.version$arch,
+          "%",
+          sep = "-"
+        )
+      )
+    )
+  )
+  for (case_name in names(token_cases)) {
+    token_case <- token_cases[[case_name]]
+    stopifnot(identical(
+      resolve_r_library(
+        root,
+        r_version = "4.3.2",
+        env = c(R_LIBS_USER = token_case$path, R_LIBS = "")
+      ),
+      normalizePath(token_case$expected, mustWork = FALSE)
+    ))
+  }
   explicit_r_lib <- file.path(root, "explicit-r-library")
   stopifnot(identical(
     resolve_r_library(
@@ -151,6 +173,35 @@ local({
   )
   stopifnot(identical(captured$pkg, "gamma"))
   stopifnot(identical(captured$upgrade, FALSE))
+
+  reference_cases <- list(
+    qualified = "cran::alpha",
+    versioned = "alpha@1.0",
+    remote = "owner/alpha@main",
+    reinstall = "alpha=?reinstall",
+    archive = "url::https://example.invalid/alpha.tar.gz"
+  )
+  for (case_name in names(reference_cases)) {
+    reference <- reference_cases[[case_name]]
+    install_pkgs(
+      reference,
+      repos = c(CRAN = requested_repo),
+      r_lib = explicit,
+      upgrade = FALSE,
+      pkg_install = fake_pkg_install,
+      installed_fn = no_upgrade_inventory,
+      status_fn = function(...) {
+        data.frame(
+          package = "alpha",
+          remotepkgref = "github::owner/alpha",
+          repotype = "github",
+          stringsAsFactors = FALSE
+        )
+      }
+    )
+    stopifnot(identical(captured$pkg, reference))
+    stopifnot(identical(captured$upgrade, FALSE))
+  }
 
   update_pkgs(
     repos = c(CRAN = requested_repo),

--- a/tests/test_util.R
+++ b/tests/test_util.R
@@ -161,7 +161,7 @@ local({
 
   captured <- NULL
   fake_pkg_install <- function(...) {
-    captured <<- list(...)
+    captured <<- c(list(repos = getOption("repos")), list(...))
     invisible(NULL)
   }
   refs <- c(
@@ -230,6 +230,38 @@ local({
     stopifnot(identical(captured$upgrade, FALSE))
   }
 
+  standard_reference_cases <- list(
+    cran = list(reference = "cran::alpha", expected = character()),
+    standard = list(reference = "standard::alpha", expected = character()),
+    versioned = list(
+      reference = "cran::alpha@1.0",
+      expected = "cran::alpha@1.0"
+    ),
+    reinstall = list(
+      reference = "standard::alpha=?reinstall",
+      expected = "standard::alpha=?reinstall"
+    )
+  )
+  ordinary_cran_status <- function(...) {
+    data.frame(
+      package = "alpha",
+      remotepkgref = NA_character_,
+      repotype = "cran",
+      repository = "CRAN",
+      stringsAsFactors = FALSE
+    )
+  }
+  for (case_name in names(standard_reference_cases)) {
+    reference_case <- standard_reference_cases[[case_name]]
+    filtered <- filter_installed_pkgs(
+      pkgs = reference_case$reference,
+      r_lib = explicit,
+      installed_fn = no_upgrade_inventory,
+      status_fn = ordinary_cran_status
+    )
+    stopifnot(identical(unname(filtered), reference_case$expected))
+  }
+
   update_pkgs(
     repos = c(CRAN = requested_repo),
     r_lib = explicit,
@@ -246,6 +278,7 @@ local({
     )
   }
   fake_status <- function(pkg, lib) {
+    custom_repo <- "https://example.invalid/internal"
     data.frame(
       package = pkg,
       remotepkgref = c(
@@ -255,6 +288,7 @@ local({
         NA
       ),
       repotype = c("cran", NA, NA, "bioc"),
+      repository = c(custom_repo, NA, NA, NA),
       stringsAsFactors = FALSE
     )
   }
@@ -273,6 +307,10 @@ local({
       "git::https://example.invalid/gamma.git",
       "bioc::delta"
     )
+  ))
+  stopifnot(identical(
+    unname(captured$repos)[[1L]],
+    "https://example.invalid/internal"
   ))
   stopifnot(identical(captured$upgrade, TRUE))
 


### PR DESCRIPTION
Implements #26, #27, #28, and #29.

## Summary

This PR modernizes clir for current R and pak workflows and prepares the v2.0.0 release.

- Route package installation and updates through pak while preserving CRAN, Bioconductor, GitHub, Git, archive, and named custom-repository references.
- Preserve and normalize repository/package metadata across configuration, status, updates, and upgrades, including migration from legacy `cran_urls` configuration.
- Make the launcher and installer agree on R-version-aware default libraries, honor explicit `R_LIBS_USER`/`R_LIBS` values, and safely reset only clir-managed libraries.
- Remove the legacy `drat`, `--devt`, and `--bioc` interfaces and update the CLI documentation.
- Add focused R and shell regression suites covering library resolution, repository/reference handling, configuration migration, reset safety, startup probes, CLI parsing, and installer behavior.
- Expand CI to Linux R-devel/release/oldrel-1 lint and regression jobs plus current-release macOS CLI smoke tests.

## Verification

Passed locally:

- `Rscript tests/test_util.R`
- `bash -n install_clir.sh tests/test_cli.sh`
- `shellcheck install_clir.sh tests/test_cli.sh`
- `actionlint .github/workflows/ci.yml`
- `yamllint -d relaxed .github/workflows/ci.yml`
- `git diff --check`

The latest CI run is not green: the macOS CLI smoke test and formatting job pass, while all three Linux `r-tests` jobs stop at the stale `v1.2.1` version assertion in `tests/test_cli.sh`. The CLI now reports `v2.0.0`.

Closes #26
Closes #27
Closes #28
Closes #29
